### PR TITLE
Merging of export_all_partition_by_date.py and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6-alpine
+MAINTAINER Eric Lim <elim0322@gmail.com>
+ENV PROJECT_DIR=ethereum-etl
+
+RUN mkdir /$PROJECT_DIR
+WORKDIR /$PROJECT_DIR
+COPY requirements.txt .
+RUN apk add --no-cache gcc musl-dev  #for C libraries: <limits.h> <stdio.h>
+RUN pip install --upgrade pip && pip install -r /$PROJECT_DIR/requirements.txt
+COPY . .
+
+ENTRYPOINT ["python", "export_all.py"]

--- a/README.md
+++ b/README.md
@@ -153,23 +153,23 @@ total_supply                 | numeric     |
 
 You can find column descriptions in [https://github.com/medvedev1088/ethereum-etl-airflow](https://github.com/medvedev1088/ethereum-etl-airflow/tree/master/dags/resources/stages/raw/schemas)
 
-Note: for the `address` type all hex characters are lower-cased. 
+Note: for the `address` type all hex characters are lower-cased.
 `boolean` type can have 2 values: `True` or `False`.
 
 ## LIMITATIONS
 
-- `contracts.csv` and `tokens.csv` files don’t include contracts created by message calls (a.k.a. internal transactions). 
+- `contracts.csv` and `tokens.csv` files don’t include contracts created by message calls (a.k.a. internal transactions).
 We are working on adding support for those.
 - In case the contract is a proxy, which forwards all calls to a delegate, interface detection doesn’t work,
 which means `is_erc20` and `is_erc721` will always be false for proxy contracts.
-- The metadata methods (`symbol`, `name`, `decimals`, `total_supply`) for ERC20 are optional, so around 10% of the 
-contracts are missing this data. Also some contracts (EOS) implement these methods but with wrong return type, 
+- The metadata methods (`symbol`, `name`, `decimals`, `total_supply`) for ERC20 are optional, so around 10% of the
+contracts are missing this data. Also some contracts (EOS) implement these methods but with wrong return type,
 so the metadata columns are missing in this case as well.
 - `token_transfers.value`, `tokens.decimals` and `tokens.total_supply` have type `STRING` in BigQuery tables,
-because numeric types there can't handle 32-byte integers. You should use 
+because numeric types there can't handle 32-byte integers. You should use
 `cast(value as FLOAT64)` (possible loss of precision) or
 `safe_cast(value as NUMERIC)` (possible overflow) to convert to numbers.
-- The contracts that don't implement `decimals()` function but have the 
+- The contracts that don't implement `decimals()` function but have the
 [fallback function](https://solidity.readthedocs.io/en/v0.4.21/contracts.html#fallback-function) that returns a `boolean`
 will have `0` or `1` in the `decimals` column in the CSVs.
 
@@ -187,8 +187,8 @@ export the data ~40 times faster, you will need to set up a local Ethereum node:
 
 1. Start geth.
 Make sure it downloaded the blocks that you need by executing `eth.syncing` in the JS console.
-You can export blocks below `currentBlock`, 
-there is no need to wait until the full sync as the state is not needed (unless you also need contracts bytecode 
+You can export blocks below `currentBlock`,
+there is no need to wait until the full sync as the state is not needed (unless you also need contracts bytecode
 and token details; for those you need to wait until the full sync).
 
 1. Clone Ethereum ETL and install the dependencies:
@@ -220,7 +220,7 @@ and token details; for those you need to wait until the full sync).
     ```
 
 Should work with geth and parity, on Linux, Mac, Windows.
-If you use Parity you should disable warp mode with `--no-warp` option because warp mode 
+If you use Parity you should disable warp mode with `--no-warp` option because warp mode
 does not place all of the block or receipt data into the database https://wiki.parity.io/Getting-Synced
 Tested with Python 3.6, geth 1.8.7, Ubuntu 16.04.4
 
@@ -244,6 +244,22 @@ Additional steps:
 
     ```bash
     >  ./export_all.sh -s 0 -e 999999 -b 100000 -p 'file:\\\\.\pipe\geth.ipc' -o output
+    ```
+
+#### Running in Docker
+
+1. Install Docker https://docs.docker.com/install/
+
+1. Build a docker image
+    ```bash
+    > docker build -t ethereum-etl:latest .
+    > docker image ls
+    ```
+
+1. Run a container out of the image
+    ```bash
+    > docker run -v $HOME/output:/ethereum-etl/output ethereum-etl:latest -s 0 -e 5499999 -b 100000 -p https://mainnet.infura.io
+    > docker run -v $HOME/output:/ethereum-etl/output ethereum-etl:latest -s 2018-01-01 -e 2018-01-01 -b 100000 -p https://mainnet.infura.io
     ```
 
 #### Command Reference
@@ -286,7 +302,7 @@ You can tune `--batch-size`, `--max-workers` for performance.
 
 ##### export_token_transfers.py
 
-The API used in this command is not supported by Infura, so you will need a local node. 
+The API used in this command is not supported by Infura, so you will need a local node.
 If you want to use Infura for exporting ERC20 transfers refer to [extract_token_transfers.py](#extract_token_transferspy)
 
 ```bash
@@ -305,7 +321,7 @@ You can tune `--batch-size`, `--max-workers` for performance.
 
 ##### export_receipts_and_logs.py
 
-First extract transaction hashes from `transactions.csv` 
+First extract transaction hashes from `transactions.csv`
 (Exported with [export_blocks_and_transactions.py](#export_blocks_and_transactionspy)):
 
 ```bash
@@ -358,7 +374,7 @@ You can tune `--batch-size`, `--max-workers` for performance.
 
 ##### export_tokens.py
 
-First extract token addresses from `contracts.json` 
+First extract token addresses from `contracts.json`
 (Exported with [export_contracts.py](#export_contractspy)):
 
 ```bash
@@ -442,4 +458,3 @@ Refer to https://github.com/medvedev1088/ethereum-etl-airflow for the instructio
 
 You can query the data that's updated daily in the public BigQuery dataset
 https://medium.com/@medvedev1088/ethereum-blockchain-on-google-bigquery-283fb300f579
-

--- a/export_all.py
+++ b/export_all.py
@@ -26,8 +26,8 @@ import argparse
 from export_all_common import export_all
 
 parser = argparse.ArgumentParser(description='Export all for a range of blocks.',
-                                 usage='-s <start_block> -e <end_block> [-b <batch_size>] [-p <provider_uri>] '
-                                       '[-o <output_dir>] [-w <max_workers>]')
+                                 usage='-s <start_block> -e <end_block> [-b <partition_batch_size>] [-p <provider_uri>] '
+                                       '[-o <output_dir>] [-w <max_workers>] [-B <export_batch_size>]')
 parser.add_argument('-s', '--start-block', default=0, type=int, help='Start block')
 parser.add_argument('-e', '--end-block', required=True, type=int, help='End block')
 parser.add_argument('-b', '--partition-batch-size', default=10000, type=int,
@@ -38,6 +38,7 @@ parser.add_argument('-p', '--provider-uri', default='https://mainnet.infura.io',
 parser.add_argument('-o', '--output-dir', default='output', type=str,
                     help='Output directory, partitioned in Hive style.')
 parser.add_argument('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+parser.add_argument('-B', '--export-batch-size', default=100, type=int, help='The number of rows to write concurrently.')
 
 args = parser.parse_args()
 
@@ -56,4 +57,4 @@ def get_partitions():
         yield batch_start_block, batch_end_block, partition_dir
 
 
-export_all(get_partitions(), args.output_dir, args.provider_uri, args.max_workers)
+export_all(get_partitions(), args.output_dir, args.provider_uri, args.max_workers, args.export_batch_size)

--- a/export_all.py
+++ b/export_all.py
@@ -22,14 +22,20 @@
 
 
 import argparse
+import re
 
+from datetime import datetime, timedelta
 from export_all_common import export_all
+from web3 import Web3
+
+from ethereumetl.providers.auto import get_provider_from_uri
+from ethereumetl.service.eth_service import EthService
 
 parser = argparse.ArgumentParser(description='Export all for a range of blocks.',
-                                 usage='-s <start_block> -e <end_block> [-b <partition_batch_size>] [-p <provider_uri>] '
+                                 usage='-s <start> -e <end> [-b <partition_batch_size>] [-p <provider_uri>] '
                                        '[-o <output_dir>] [-w <max_workers>] [-B <export_batch_size>]')
-parser.add_argument('-s', '--start-block', default=0, type=int, help='Start block')
-parser.add_argument('-e', '--end-block', required=True, type=int, help='End block')
+parser.add_argument('-s', '--start', required=True, type=str, help='Start block/ISO date/Unix time')
+parser.add_argument('-e', '--end', required=True, type=str, help='End block/ISO date/Unix time')
 parser.add_argument('-b', '--partition-batch-size', default=10000, type=int,
                     help='The number of blocks to export in partition.')
 parser.add_argument('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
@@ -42,19 +48,60 @@ parser.add_argument('-B', '--export-batch-size', default=100, type=int, help='Th
 
 args = parser.parse_args()
 
+def is_date_range():
+    """Checks for YYYY-MM-DD date format."""
+    return bool(re.match('^2[0-9]{3}-[0-9]{2}-[0-9]{2}$', args.start) and
+                re.match('^2[0-9]{3}-[0-9]{2}-[0-9]{2}$', args.end))
+
+def is_unix_time_range():
+    """Checks for Unix timestamp format."""
+    return bool(re.match("^[0-9]{10}$|^[0-9]{13}$", args.start) and
+                re.match("^[0-9]{10}$|^[0-9]{13}$", args.end))
+
+def is_block_range():
+    """Checks for a valid block number."""
+    return (int(args.start) >= 0 and int(args.start) <= 99999999 and
+            int(args.end)   >= 0 and int(args.end)   <= 99999999)
 
 def get_partitions():
-    for batch_start_block in range(args.start_block, args.end_block + 1, args.partition_batch_size):
-        batch_end_block = batch_start_block + args.partition_batch_size - 1
-        if batch_end_block > args.end_block:
-            batch_end_block = args.end_block
+    if is_date_range() or is_unix_time_range():
+        if is_date_range():
+            start_date = datetime.strptime(args.start, '%Y-%m-%d').date()
+            end_date = datetime.strptime(args.end, '%Y-%m-%d').date()
 
-        padded_batch_start_block = str(batch_start_block).zfill(8)
-        padded_batch_end_block = str(batch_end_block).zfill(8)
+        elif is_unix_time_range():
+            if len(args.start) == 10 and len(args.end) == 10:
+                start_date = datetime.utcfromtimestamp(int(args.start)).date()
+                end_date = datetime.utcfromtimestamp(int(args.end)).date()
 
-        partition_dir = f'/start_block={padded_batch_start_block}/end_block={padded_batch_end_block}'
+            elif len(args.start) == 13 and len(args.end) == 13:
+                start_date = datetime.utcfromtimestamp(int(args.start)/1e3).date()
+                end_date = datetime.utcfromtimestamp(int(args.end)/1e3).date()
 
-        yield batch_start_block, batch_end_block, partition_dir
+        day = timedelta(days=1)
 
+        provider = get_provider_from_uri(args.provider_uri)
+        web3 = Web3(provider)
+        eth_service = EthService(web3)
+
+        while start_date <= end_date:
+            batch_start_block, batch_end_block = eth_service.get_block_range_for_date(start_date)
+            partition_dir = '/date=' + str(start_date)
+            yield batch_start_block, batch_end_block, partition_dir
+            start_date += day
+
+    elif is_block_range():
+        start_block = int(args.start)
+        end_block = int(args.end)
+
+        for batch_start_block in range(start_block, end_block + 1, args.partition_batch_size):
+            batch_end_block = batch_start_block + args.partition_batch_size - 1
+            if batch_end_block > end_block:
+                batch_end_block = end_block
+
+            padded_batch_start_block = str(batch_start_block).zfill(8)
+            padded_batch_end_block = str(batch_end_block).zfill(8)
+            partition_dir = f'/start_block={padded_batch_start_block}/end_block={padded_batch_end_block}'
+            yield batch_start_block, batch_end_block, partition_dir
 
 export_all(get_partitions(), args.output_dir, args.provider_uri, args.max_workers, args.export_batch_size)

--- a/export_all_common.py
+++ b/export_all_common.py
@@ -65,8 +65,7 @@ def extract_csv_column_unique(input, output, column):
             output_file.write(row[column] + '\n')
 
 
-def export_all(partitions, output_dir, provider_uri, max_workers):
-    batch_size = 100
+def export_all(partitions, output_dir, provider_uri, max_workers, batch_size):
 
     for batch_start_block, batch_end_block, partition_dir in partitions:
         # # # start # # #

--- a/export_all_partition_by_date.py
+++ b/export_all_partition_by_date.py
@@ -32,7 +32,7 @@ from export_all_common import export_all
 
 parser = argparse.ArgumentParser(description='Export all for a range of blocks.',
                                  usage='-s <start_date> -e <end_date> [-p <provider_uri>] '
-                                       '[-o <output_dir>] [-w <max_workers>]')
+                                       '[-o <output_dir>] [-w <max_workers>] [-B <export_batch_size>]')
 parser.add_argument('-s', '--start-date', default='2015-07-30', type=str, help='Start date (YYYY-MM-DD)')
 parser.add_argument('-e', '--end-date', required=True, type=str, help='End date (YYYY-MM-DD)')
 parser.add_argument('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
@@ -40,6 +40,7 @@ parser.add_argument('-p', '--provider-uri', default='https://mainnet.infura.io',
                          'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 parser.add_argument('-o', '--output-dir', default='output', type=str, help='Output directory, partitioned in Hive style.')
 parser.add_argument('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+parser.add_argument('-B', '--export-batch-size', default=100, type=int, help='The number of rows to write concurrently.')
 
 args = parser.parse_args()
 
@@ -63,4 +64,4 @@ def get_partitions():
         start_date += day
 
 
-export_all(get_partitions(), args.output_dir, args.provider_uri, args.max_workers)
+export_all(get_partitions(), args.output_dir, args.provider_uri, args.max_workers, args.export_batch_size)


### PR DESCRIPTION
Creating a PR as it looks like my stuff is blocking Issue #91.

Dockerfile is tested with RPC but the IPC requirement is not yet met. Running the below command returns "connection refused" error:
```
docker run \
--mount type=bind,source=$HOME/Library/Ethereum,target=/ethereum-etl/Ethereum,readonly \
--mount type=bind,source=$HOME/output,target=/ethereum-etl/output \
ethereum-etl:latest \
-s 1 -e 1 -p file:///ethereum-etl/Ethereum/geth.ipc
```
Tried with `--ipc=host` option with no success. The `geth.ipc` file is successfully mounted to the container but cannot seem to establish connection. I opened a question on Stack Overflow: https://stackoverflow.com/questions/52715141/how-to-make-a-docker-container-talk-to-geth-on-local-host


Changes:
1. `export_all_partition_by_date.py` is now merged into `export_all.py` such that `-s` and `-e` arguments take (1) start and end block range, (2) date range and (3) Unix time range with and without milliseconds.

1. `batch_size` is pulled out as `-B --export-batch-size`

1. Added Dockerfile and updated README.md with instructions (under Exporting the Blockchain)

