### PR TITLE
Added to pip. Now you can use pip install ethereum-etl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="ethereum-etl",
+    version="0.0.1",
+    author="Evgeny Medvedev",
+    author_email="medvedev1088@gmail.com",
+    description="Python scripts for ETL (extract, transform and load) jobs for Ethereum blocks, transactions... etc",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/blockchain-etl/ethereum-etl",
+    packages=setuptools.find_packages(),
+    include_package_data=True,
+    install_requires=[],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
Packaging
---------
[nice tutorial](https://packaging.python.org/tutorials/packaging-projects/)
* Install latest versions of `setuptools` and `wheel`::

	`pip install setuptools wheel`
	`pip install twine`

* Once installed, run run this command from the same directory where `setup.py` is located:

	`python3 setup.py sdist bdist_wheel`

* Register an account on https://pypi.org (for testing you can use https://test.pypi.org/).

* Now, run Twine to upload all of the archives under `dist`:

	`twine upload dist/*`
Enter your credentials for the account you registered on the PyPI.

Updating your distribution
--------------------------

Down the road, after you’ve made updates to your distribution and wish to make a new release:

* increment the `version` number in your `setup.py` file,
* remove the `dist` folder, and regenerate the archives.
* run `python3 setup.py sdist bdist_wheel`
* upload it `twine upload dist/*`