### PR TITLE
Add chain command line argument for EVM Agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ error                        | string      |
 
 You can find column descriptions in [https://github.com/medvedev1088/ethereum-etl-airflow](https://github.com/medvedev1088/ethereum-etl-airflow/tree/master/dags/resources/stages/raw/schemas)
 
+# Ethereum Classic
+
+For getting ETC csv files, make sure you pass in the `--chain classic` param where it's required for the scripts you want to export. 
+ETC won't run if your `--provider-uri` is Infura. Only `parity chain=classic` and Geth-classic will work.
+
 Note: for the `address` type all hex characters are lower-cased.
 `boolean` type can have 2 values: `True` or `False`.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ You can find column descriptions in [https://github.com/medvedev1088/ethereum-et
 # Ethereum Classic
 
 For getting ETC csv files, make sure you pass in the `--chain classic` param where it's required for the scripts you want to export. 
-ETC won't run if your `--provider-uri` is Infura. Only `parity chain=classic` and Geth-classic will work.
+ETC won't run if your `--provider-uri` is Infura. It will provide a warning and change the provider-uri to `https://ethereumclassic.network` instead. For faster performance, run a client instead locally for classic such as `parity chain=classic` and Geth-classic.
 
 Note: for the `address` type all hex characters are lower-cased.
 `boolean` type can have 2 values: `True` or `False`.

--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -110,7 +110,11 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 @click.option('-o', '--output-dir', default='output', type=str, help='Output directory, partitioned in Hive style.')
 @click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
 @click.option('-B', '--export-batch-size', default=100, type=int, help='The number of requests in JSON RPC batches.')
-def export_all(start, end, partition_batch_size, provider_uri, output_dir, max_workers, export_batch_size):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def export_all(start, end, partition_batch_size, provider_uri, output_dir, max_workers, export_batch_size, chain):
     """Exports all data for a range of blocks."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     export_all_common(get_partitions(start, end, partition_batch_size, provider_uri),
                       output_dir, provider_uri, max_workers, export_batch_size)

--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -115,6 +115,6 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 
 def export_all(start, end, partition_batch_size, provider_uri, output_dir, max_workers, export_batch_size, chain):
     """Exports all data for a range of blocks."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     export_all_common(get_partitions(start, end, partition_batch_size, provider_uri),
                       output_dir, provider_uri, max_workers, export_batch_size)

--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -30,6 +30,7 @@ from web3 import Web3
 from ethereumetl.jobs.export_all_common import export_all_common
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.service.eth_service import EthService
+from ethereumetl.utils import check_classic_provider_uri
 
 
 def is_date_range(start, end):
@@ -114,7 +115,6 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 
 def export_all(start, end, partition_batch_size, provider_uri, output_dir, max_workers, export_batch_size, chain):
     """Exports all data for a range of blocks."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     export_all_common(get_partitions(start, end, partition_batch_size, provider_uri),
                       output_dir, provider_uri, max_workers, export_batch_size)

--- a/ethereumetl/cli/export_blocks_and_transactions.py
+++ b/ethereumetl/cli/export_blocks_and_transactions.py
@@ -28,6 +28,7 @@ from ethereumetl.jobs.exporters.blocks_and_transactions_item_exporter import blo
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
+from ethereumetl.utils import check_classic_provider_uri
 
 logging_basic_config()
 
@@ -47,10 +48,9 @@ logging_basic_config()
                    'If not provided transactions will not be exported. Use "-" for stdout')
 @click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
 
-def export_blocks_and_transactions(start_block, end_block, batch_size, provider_uri, max_workers, blocks_output, transactions_output):
+def export_blocks_and_transactions(start_block, end_block, batch_size, provider_uri, max_workers, blocks_output, transactions_output, chain):
     """Exports blocks and transactions."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     if blocks_output is None and transactions_output is None:
         raise ValueError('Either --blocks-output or --transactions-output options must be provided')
 

--- a/ethereumetl/cli/export_blocks_and_transactions.py
+++ b/ethereumetl/cli/export_blocks_and_transactions.py
@@ -50,7 +50,7 @@ logging_basic_config()
 
 def export_blocks_and_transactions(start_block, end_block, batch_size, provider_uri, max_workers, blocks_output, transactions_output, chain):
     """Exports blocks and transactions."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     if blocks_output is None and transactions_output is None:
         raise ValueError('Either --blocks-output or --transactions-output options must be provided')
 

--- a/ethereumetl/cli/export_blocks_and_transactions.py
+++ b/ethereumetl/cli/export_blocks_and_transactions.py
@@ -45,8 +45,12 @@ logging_basic_config()
 @click.option('--transactions-output', default=None, type=str,
               help='The output file for transactions. '
                    'If not provided transactions will not be exported. Use "-" for stdout')
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
 def export_blocks_and_transactions(start_block, end_block, batch_size, provider_uri, max_workers, blocks_output, transactions_output):
     """Exports blocks and transactions."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     if blocks_output is None and transactions_output is None:
         raise ValueError('Either --blocks-output or --transactions-output options must be provided')
 

--- a/ethereumetl/cli/export_contracts.py
+++ b/ethereumetl/cli/export_contracts.py
@@ -42,8 +42,12 @@ logging_basic_config()
 @click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-def export_contracts(batch_size, contract_addresses, output, max_workers, provider_uri):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def export_contracts(batch_size, contract_addresses, output, max_workers, provider_uri, chain):
     """Exports contracts bytecode and sighashes."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     with smart_open(contract_addresses, 'r') as contract_addresses_file:
         contract_addresses = (contract_address.strip() for contract_address in contract_addresses_file
                               if contract_address.strip())

--- a/ethereumetl/cli/export_contracts.py
+++ b/ethereumetl/cli/export_contracts.py
@@ -29,6 +29,7 @@ from ethereumetl.jobs.exporters.contracts_item_exporter import contracts_item_ex
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
+from ethereumetl.utils import check_classic_provider_uri
 
 logging_basic_config()
 
@@ -46,8 +47,7 @@ logging_basic_config()
 
 def export_contracts(batch_size, contract_addresses, output, max_workers, provider_uri, chain):
     """Exports contracts bytecode and sighashes."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     with smart_open(contract_addresses, 'r') as contract_addresses_file:
         contract_addresses = (contract_address.strip() for contract_address in contract_addresses_file
                               if contract_address.strip())

--- a/ethereumetl/cli/export_receipts_and_logs.py
+++ b/ethereumetl/cli/export_receipts_and_logs.py
@@ -46,8 +46,12 @@ logging_basic_config()
 @click.option('--logs-output', default=None, type=str,
               help='The output file for receipt logs. '
                    'aIf not provided receipt logs will not be exported. Use "-" for stdout')
-def export_receipts_and_logs(batch_size, transaction_hashes, provider_uri, max_workers, receipts_output, logs_output):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def export_receipts_and_logs(batch_size, transaction_hashes, provider_uri, max_workers, receipts_output, logs_output, chain):
     """Exports receipts and logs."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     with smart_open(transaction_hashes, 'r') as transaction_hashes_file:
         job = ExportReceiptsJob(
             transaction_hashes_iterable=(transaction_hash.strip() for transaction_hash in transaction_hashes_file),

--- a/ethereumetl/cli/export_receipts_and_logs.py
+++ b/ethereumetl/cli/export_receipts_and_logs.py
@@ -29,6 +29,7 @@ from ethereumetl.jobs.exporters.receipts_and_logs_item_exporter import receipts_
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
+from ethereumetl.utils import check_classic_provider_uri
 
 logging_basic_config()
 
@@ -50,8 +51,7 @@ logging_basic_config()
 
 def export_receipts_and_logs(batch_size, transaction_hashes, provider_uri, max_workers, receipts_output, logs_output, chain):
     """Exports receipts and logs."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     with smart_open(transaction_hashes, 'r') as transaction_hashes_file:
         job = ExportReceiptsJob(
             transaction_hashes_iterable=(transaction_hash.strip() for transaction_hash in transaction_hashes_file),

--- a/ethereumetl/cli/export_receipts_and_logs.py
+++ b/ethereumetl/cli/export_receipts_and_logs.py
@@ -51,7 +51,7 @@ logging_basic_config()
 
 def export_receipts_and_logs(batch_size, transaction_hashes, provider_uri, max_workers, receipts_output, logs_output, chain):
     """Exports receipts and logs."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     with smart_open(transaction_hashes, 'r') as transaction_hashes_file:
         job = ExportReceiptsJob(
             transaction_hashes_iterable=(transaction_hash.strip() for transaction_hash in transaction_hashes_file),

--- a/ethereumetl/cli/export_tokens.py
+++ b/ethereumetl/cli/export_tokens.py
@@ -47,7 +47,7 @@ logging_basic_config()
 
 def export_tokens(token_addresses, output, max_workers, provider_uri, chain):
     """Exports ERC20/ERC721 tokens."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     with smart_open(token_addresses, 'r') as token_addresses_file:
         job = ExportTokensJob(
             token_addresses_iterable=(token_address.strip() for token_address in token_addresses_file),

--- a/ethereumetl/cli/export_tokens.py
+++ b/ethereumetl/cli/export_tokens.py
@@ -42,8 +42,12 @@ logging_basic_config()
 @click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-def export_tokens(token_addresses, output, max_workers, provider_uri):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def export_tokens(token_addresses, output, max_workers, provider_uri, chain):
     """Exports ERC20/ERC721 tokens."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     with smart_open(token_addresses, 'r') as token_addresses_file:
         job = ExportTokensJob(
             token_addresses_iterable=(token_address.strip() for token_address in token_addresses_file),

--- a/ethereumetl/cli/export_tokens.py
+++ b/ethereumetl/cli/export_tokens.py
@@ -31,6 +31,7 @@ from ethereumetl.jobs.exporters.tokens_item_exporter import tokens_item_exporter
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
+from ethereumetl.utils import check_classic_provider_uri
 
 logging_basic_config()
 
@@ -46,8 +47,7 @@ logging_basic_config()
 
 def export_tokens(token_addresses, output, max_workers, provider_uri, chain):
     """Exports ERC20/ERC721 tokens."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     with smart_open(token_addresses, 'r') as token_addresses_file:
         job = ExportTokensJob(
             token_addresses_iterable=(token_address.strip() for token_address in token_addresses_file),

--- a/ethereumetl/cli/export_traces.py
+++ b/ethereumetl/cli/export_traces.py
@@ -45,9 +45,13 @@ logging_basic_config()
                    'file://$HOME/.local/share/io.parity.ethereum/jsonrpc.ipc or http://localhost:8545/')
 @click.option('--genesis-traces/--no-genesis-traces', default=False, help='Whether to include genesis traces')
 @click.option('--daofork-traces/--no-daofork-traces', default=False, help='Whether to include daofork traces')
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
 def export_traces(start_block, end_block, batch_size, output, max_workers, provider_uri,
-                  genesis_traces, daofork_traces):
+                  genesis_traces, daofork_traces, chain):
     """Exports traces from parity node."""
+    if chain == 'classic' and daofork_traces == True:
+        raise ValueError('Classic chain does not include daofork traces. Disable daofork traces with --no-daofork-traces option.')
     job = ExportTracesJob(
         start_block=start_block,
         end_block=end_block,

--- a/ethereumetl/cli/get_block_range_for_date.py
+++ b/ethereumetl/cli/get_block_range_for_date.py
@@ -30,6 +30,7 @@ from ethereumetl.file_utils import smart_open
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.service.eth_service import EthService
 from ethereumetl.providers.auto import get_provider_from_uri
+from ethereumetl.utils import check_classic_provider_uri
 
 logging_basic_config()
 
@@ -45,8 +46,7 @@ logging_basic_config()
 
 def get_block_range_for_date(provider_uri, date, output, chain):
     """Outputs start and end blocks for given date."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/cli/get_block_range_for_date.py
+++ b/ethereumetl/cli/get_block_range_for_date.py
@@ -46,7 +46,7 @@ logging_basic_config()
 
 def get_block_range_for_date(provider_uri, date, output, chain):
     """Outputs start and end blocks for given date."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/cli/get_block_range_for_date.py
+++ b/ethereumetl/cli/get_block_range_for_date.py
@@ -41,8 +41,12 @@ logging_basic_config()
 @click.option('-d', '--date', required=True, type=lambda d: datetime.strptime(d, '%Y-%m-%d'),
               help='The date e.g. 2018-01-01.')
 @click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-def get_block_range_for_date(provider_uri, date, output):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def get_block_range_for_date(provider_uri, date, output, chain):
     """Outputs start and end blocks for given date."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/cli/get_block_range_for_timestamps.py
+++ b/ethereumetl/cli/get_block_range_for_timestamps.py
@@ -45,7 +45,7 @@ logging_basic_config()
 
 def get_block_range_for_timestamps(provider_uri, start_timestamp, end_timestamp, output, chain):
     """Outputs start and end blocks for given timestamps."""
-    check_classic_provider_uri(chain, provider_uri)
+    provider_uri = check_classic_provider_uri(chain, provider_uri)
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/cli/get_block_range_for_timestamps.py
+++ b/ethereumetl/cli/get_block_range_for_timestamps.py
@@ -29,6 +29,7 @@ from ethereumetl.file_utils import smart_open
 from ethereumetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.service.eth_service import EthService
+from ethereumetl.utils import check_classic_provider_uri 
 
 logging_basic_config()
 
@@ -44,8 +45,7 @@ logging_basic_config()
 
 def get_block_range_for_timestamps(provider_uri, start_timestamp, end_timestamp, output, chain):
     """Outputs start and end blocks for given timestamps."""
-    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+    check_classic_provider_uri(chain, provider_uri)
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/cli/get_block_range_for_timestamps.py
+++ b/ethereumetl/cli/get_block_range_for_timestamps.py
@@ -40,8 +40,12 @@ logging_basic_config()
 @click.option('-s', '--start-timestamp', required=True, type=int, help='Start unix timestamp, in seconds.')
 @click.option('-e', '--end-timestamp', required=True, type=int, help='End unix timestamp, in seconds.')
 @click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-def get_block_range_for_timestamps(provider_uri, start_timestamp, end_timestamp, output):
+@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+
+def get_block_range_for_timestamps(provider_uri, start_timestamp, end_timestamp, output, chain):
     """Outputs start and end blocks for given timestamps."""
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
     provider = get_provider_from_uri(provider_uri)
     web3 = Web3(provider)
     eth_service = EthService(web3)

--- a/ethereumetl/utils.py
+++ b/ethereumetl/utils.py
@@ -22,6 +22,7 @@
 
 
 import itertools
+import warnings
 
 
 def hex_to_dec(hex_string):
@@ -95,4 +96,6 @@ def pairwise(iterable):
 
 def check_classic_provider_uri(chain, provider_uri):
     if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
-        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")
+        warnings.warn("ETC Chain not supported on Infura.io. Using https://ethereumclassic.network instead")
+        return 'https://ethereumclassic.network'
+    return provider_uri

--- a/ethereumetl/utils.py
+++ b/ethereumetl/utils.py
@@ -92,3 +92,7 @@ def pairwise(iterable):
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
+
+def check_classic_provider_uri(chain, provider_uri):
+    if chain == 'classic' and provider_uri == 'https://mainnet.infura.io':
+        raise ValueError("Classic chain isn't supported in Infura. Use parity classic chain or geth-classic instead.")


### PR DESCRIPTION
Added `--chain` argument to the cli interface. For now, it defaults to `ethereum`, but it can run `classic` as long as the `--provider-uri` isn't Infura.io. It will show a warning if Infura is passed or you're running it as default, and then modify the provider-uri to `https://ethereumclassic.network` instead. For performance boost, need to specify Parity classic chain or Geth Classic that you should be running locally.

Another thing, for `export_traces.py`, it will raise a ValueError if you pass in `--chain classic --daofork-traces` because Ethereum Classic did not have an irregular state change. Must pass `--chain classic --no-daofork-traces` instead.