### PR TITLE
Use traceFilter instead of traceBlock

### DIFF
--- a/tests/ethereumetl/job/mock_web3_provider.py
+++ b/tests/ethereumetl/job/mock_web3_provider.py
@@ -35,10 +35,6 @@ class MockWeb3Provider(IPCProvider):
             to = params[0]['to'].lower()
             data = params[0]['data']
             file_name = '{}_{}_{}.json'.format(method, to, data)
-        # TODO: Remove this when this issue is fixed
-        # https://github.com/paritytech/parity-ethereum/issues/9822
-        elif method == 'trace_block':
-            file_name = 'trace_filter.json'
         else:
             file_name = method + '.json'
         file_content = self.read_resource(file_name)


### PR DESCRIPTION
I found the TODO related to paritytech/parity-ethereum/issues/9822 and confirmed the issue has already fixed. So, I applied a reverse patch from 0b3f4d6.

I tried to verify that this patch works, but [infura.io](https://infura.io/) doesn't provide trace api and I don't have fully synchronized ethereum infrastructure.

Could you review and confirm this patch works?