### PR TITLE
Show default values for click commands when using --help

### DIFF
--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -107,15 +107,15 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-s', '--start', required=True, type=str, help='Start block/ISO date/Unix time')
 @click.option('-e', '--end', required=True, type=str, help='End block/ISO date/Unix time')
-@click.option('-b', '--partition-batch-size', default=10000, type=int,
+@click.option('-b', '--partition-batch-size', default=10000, show_default=True, type=int,
               help='The number of blocks to export in partition.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-o', '--output-dir', default='output', type=str, help='Output directory, partitioned in Hive style.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
-@click.option('-B', '--export-batch-size', default=100, type=int, help='The number of requests in JSON RPC batches.')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-o', '--output-dir', default='output', show_default=True, type=str, help='Output directory, partitioned in Hive style.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
+@click.option('-B', '--export-batch-size', default=100, show_default=True, type=int, help='The number of requests in JSON RPC batches.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_all(start, end, partition_batch_size, provider_uri, output_dir, max_workers, export_batch_size,
                chain='ethereum'):
     """Exports all data for a range of blocks."""

--- a/ethereumetl/cli/export_blocks_and_transactions.py
+++ b/ethereumetl/cli/export_blocks_and_transactions.py
@@ -34,19 +34,19 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-s', '--start-block', default=0, type=int, help='Start block')
+@click.option('-s', '--start-block', default=0, show_default=True, type=int, help='Start block')
 @click.option('-e', '--end-block', required=True, type=int, help='End block')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to export at a time.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to export at a time.')
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
-@click.option('--blocks-output', default=None, type=str,
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
+@click.option('--blocks-output', default=None, show_default=True, type=str,
               help='The output file for blocks. If not provided blocks will not be exported. Use "-" for stdout')
-@click.option('--transactions-output', default=None, type=str,
+@click.option('--transactions-output', default=None, show_default=True, type=str,
               help='The output file for transactions. '
                    'If not provided transactions will not be exported. Use "-" for stdout')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_blocks_and_transactions(start_block, end_block, batch_size, provider_uri, max_workers, blocks_output,
                                    transactions_output, chain='ethereum'):
     """Exports blocks and transactions."""

--- a/ethereumetl/cli/export_contracts.py
+++ b/ethereumetl/cli/export_contracts.py
@@ -35,15 +35,15 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to filter at a time.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to filter at a time.')
 @click.option('-c', '--contract-addresses', required=True, type=str,
               help='The file containing contract addresses, one per line.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_contracts(batch_size, contract_addresses, output, max_workers, provider_uri, chain='ethereum'):
     """Exports contracts bytecode and sighashes."""
     check_classic_provider_uri(chain, provider_uri)

--- a/ethereumetl/cli/export_geth_traces.py
+++ b/ethereumetl/cli/export_geth_traces.py
@@ -33,12 +33,12 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-s', '--start-block', default=0, type=int, help='Start block')
+@click.option('-s', '--start-block', default=0, show_default=True, type=int, help='Start block')
 @click.option('-e', '--end-block', required=True, type=int, help='End block')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to process at a time.')
-@click.option('-o', '--output', default='-', type=str,
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to process at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str,
               help='The output file for geth traces. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 @click.option('-p', '--provider-uri', required=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or http://localhost:8545/')

--- a/ethereumetl/cli/export_receipts_and_logs.py
+++ b/ethereumetl/cli/export_receipts_and_logs.py
@@ -35,19 +35,19 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of receipts to export at a time.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of receipts to export at a time.')
 @click.option('-t', '--transaction-hashes', required=True, type=str,
               help='The file containing transaction hashes, one per line.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
-@click.option('--receipts-output', default=None, type=str,
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
+@click.option('--receipts-output', default=None, show_default=True, type=str,
               help='The output file for receipts. If not provided receipts will not be exported. Use "-" for stdout')
-@click.option('--logs-output', default=None, type=str,
+@click.option('--logs-output', default=None, show_default=True, type=str,
               help='The output file for receipt logs. '
                    'aIf not provided receipt logs will not be exported. Use "-" for stdout')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_receipts_and_logs(batch_size, transaction_hashes, provider_uri, max_workers, receipts_output, logs_output,
                              chain='ethereum'):
     """Exports receipts and logs."""

--- a/ethereumetl/cli/export_token_transfers.py
+++ b/ethereumetl/cli/export_token_transfers.py
@@ -35,14 +35,14 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-s', '--start-block', default=0, type=int, help='Start block')
+@click.option('-s', '--start-block', default=0, show_default=True, type=int, help='Start block')
 @click.option('-e', '--end-block', required=True, type=int, help='End block')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to filter at a time.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to filter at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 @click.option('-p', '--provider-uri', required=True, type=str,
               help='The URI of the web3 provider e.g. file://$HOME/Library/Ethereum/geth.ipc or http://localhost:8545/')
-@click.option('-t', '--tokens', default=None, type=str, nargs=1, help='The list of token addresses to filter by.')
+@click.option('-t', '--tokens', default=None, show_default=True, type=str, nargs=1, help='The list of token addresses to filter by.')
 def export_token_transfers(start_block, end_block, batch_size, output, max_workers, provider_uri, tokens):
     """Exports ERC20/ERC721 transfers."""
     job = ExportTokenTransfersJob(

--- a/ethereumetl/cli/export_tokens.py
+++ b/ethereumetl/cli/export_tokens.py
@@ -39,12 +39,12 @@ logging_basic_config()
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-t', '--token-addresses', required=True, type=str,
               help='The file containing token addresses, one per line.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_tokens(token_addresses, output, max_workers, provider_uri, chain='ethereum'):
     """Exports ERC20/ERC721 tokens."""
     provider_uri = check_classic_provider_uri(chain, provider_uri)

--- a/ethereumetl/cli/export_traces.py
+++ b/ethereumetl/cli/export_traces.py
@@ -35,18 +35,18 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-s', '--start-block', default=0, type=int, help='Start block')
+@click.option('-s', '--start-block', default=0, show_default=True, type=int, help='Start block')
 @click.option('-e', '--end-block', required=True, type=int, help='End block')
-@click.option('-b', '--batch-size', default=5, type=int, help='The number of blocks to filter at a time.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-b', '--batch-size', default=5, show_default=True, type=int, help='The number of blocks to filter at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 @click.option('-p', '--provider-uri', required=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/.local/share/io.parity.ethereum/jsonrpc.ipc or http://localhost:8545/')
-@click.option('--genesis-traces/--no-genesis-traces', default=False, help='Whether to include genesis traces')
-@click.option('--daofork-traces/--no-daofork-traces', default=False, help='Whether to include daofork traces')
-@click.option('-t', '--timeout', default=60, type=int, help='IPC or HTTP request timeout.')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('--genesis-traces/--no-genesis-traces', default=False, show_default=True, help='Whether to include genesis traces')
+@click.option('--daofork-traces/--no-daofork-traces', default=False, show_default=True, help='Whether to include daofork traces')
+@click.option('-t', '--timeout', default=60, show_default=True, type=int, help='IPC or HTTP request timeout.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_traces(start_block, end_block, batch_size, output, max_workers, provider_uri,
                   genesis_traces, daofork_traces, timeout=60, chain='ethereum'):
     """Exports traces from parity node."""

--- a/ethereumetl/cli/extract_contracts.py
+++ b/ethereumetl/cli/extract_contracts.py
@@ -36,9 +36,9 @@ logging_basic_config()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-t', '--traces', type=str, required=True, help='The CSV file containing traces.')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to filter at a time.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to filter at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 def extract_contracts(traces, batch_size, output, max_workers):
     """Extracts contracts from traces file."""
 

--- a/ethereumetl/cli/extract_csv_column.py
+++ b/ethereumetl/cli/extract_csv_column.py
@@ -29,8 +29,8 @@ from blockchainetl.file_utils import smart_open
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-i', '--input', default='-', type=str, help='The input file. If not specified stdin is used.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
+@click.option('-i', '--input', default='-', show_default=True, type=str, help='The input file. If not specified stdin is used.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 @click.option('-c', '--column', required=True, type=str, help='The csv column name to extract.')
 def extract_csv_column(input, output, column):
     """Extracts column from given CSV file. Deprecated - use extract_field."""

--- a/ethereumetl/cli/extract_field.py
+++ b/ethereumetl/cli/extract_field.py
@@ -27,8 +27,8 @@ from ethereumetl import misc_utils
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-i', '--input', default='-', type=str, help='The input file. If not specified stdin is used.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
+@click.option('-i', '--input', default='-', show_default=True, type=str, help='The input file. If not specified stdin is used.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 @click.option('-f', '--field', required=True, type=str, help='The field name to extract.')
 def extract_field(input, output, field):
     """Extracts field from given CSV or JSON newline-delimited file."""

--- a/ethereumetl/cli/extract_geth_traces.py
+++ b/ethereumetl/cli/extract_geth_traces.py
@@ -34,9 +34,9 @@ logging_basic_config()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-i', '--input', required=True, type=str, help='The JSON file containing geth traces.')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to filter at a time.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to filter at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 def extract_geth_traces(input, batch_size, output, max_workers):
     """Extracts geth traces from JSON lines file."""
     with smart_open(input, 'r') as geth_traces_file:

--- a/ethereumetl/cli/extract_token_transfers.py
+++ b/ethereumetl/cli/extract_token_transfers.py
@@ -35,9 +35,9 @@ logging_basic_config()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-l', '--logs', type=str, required=True, help='The CSV file containing receipt logs.')
-@click.option('-b', '--batch-size', default=100, type=int, help='The number of blocks to filter at a time.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to filter at a time.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 def extract_token_transfers(logs, batch_size, output, max_workers):
     """Extracts ERC20/ERC721 transfers from logs file."""
     with smart_open(logs, 'r') as logs_file:

--- a/ethereumetl/cli/extract_tokens.py
+++ b/ethereumetl/cli/extract_tokens.py
@@ -39,11 +39,11 @@ logging_basic_config()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-c', '--contracts', type=str, required=True, help='The JSON file containing contracts.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-w', '--max-workers', default=5, type=int, help='The maximum number of workers.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 def extract_tokens(contracts, provider_uri, output, max_workers):
     """Extracts tokens from contracts file."""
 

--- a/ethereumetl/cli/filter_items.py
+++ b/ethereumetl/cli/filter_items.py
@@ -26,8 +26,8 @@ from ethereumetl import misc_utils
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-i', '--input', default='-', type=str, help='The input file. If not specified stdin is used.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
+@click.option('-i', '--input', default='-', show_default=True, type=str, help='The input file. If not specified stdin is used.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 @click.option('-p', '--predicate', required=True, type=str,
               help='Predicate in Python code e.g. "item[\'is_erc20\']".')
 def filter_items(input, output, predicate):

--- a/ethereumetl/cli/get_block_range_for_date.py
+++ b/ethereumetl/cli/get_block_range_for_date.py
@@ -36,13 +36,13 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-d', '--date', required=True, type=lambda d: datetime.strptime(d, '%Y-%m-%d'),
               help='The date e.g. 2018-01-01.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def get_block_range_for_date(provider_uri, date, output, chain='ethereum'):
     """Outputs start and end blocks for given date."""
     provider_uri = check_classic_provider_uri(chain, provider_uri)

--- a/ethereumetl/cli/get_block_range_for_timestamps.py
+++ b/ethereumetl/cli/get_block_range_for_timestamps.py
@@ -35,13 +35,13 @@ logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-s', '--start-timestamp', required=True, type=int, help='Start unix timestamp, in seconds.')
 @click.option('-e', '--end-timestamp', required=True, type=int, help='End unix timestamp, in seconds.')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
-@click.option('-c', '--chain', default='ethereum', type=str, help='The chain network to connect to.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
+@click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def get_block_range_for_timestamps(provider_uri, start_timestamp, end_timestamp, output, chain='ethereum'):
     """Outputs start and end blocks for given timestamps."""
     provider_uri = check_classic_provider_uri(chain, provider_uri)

--- a/ethereumetl/cli/get_keccak_hash.py
+++ b/ethereumetl/cli/get_keccak_hash.py
@@ -30,9 +30,9 @@ from blockchainetl.logging_utils import logging_basic_config
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-i', '--input-string', default='Transfer(address,address,uint256)', type=str,
+@click.option('-i', '--input-string', default='Transfer(address,address,uint256)', show_default=True, type=str,
               help='String to hash, e.g. Transfer(address,address,uint256)')
-@click.option('-o', '--output', default='-', type=str, help='The output file. If not specified stdout is used.')
+@click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 def get_keccak_hash(input_string, output):
     """Outputs 32-byte Keccak hash of given string."""
     hash = keccak(text=input_string)

--- a/ethereumetl/cli/stream.py
+++ b/ethereumetl/cli/stream.py
@@ -31,23 +31,23 @@ from ethereumetl.thread_local_proxy import ThreadLocalProxy
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-l', '--last-synced-block-file', default='last_synced_block.txt', type=str, help='')
-@click.option('--lag', default=0, type=int, help='The number of blocks to lag behind the network.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', type=str,
+@click.option('-l', '--last-synced-block-file', default='last_synced_block.txt', show_default=True, type=str, help='')
+@click.option('--lag', default=0, show_default=True, type=int, help='The number of blocks to lag behind the network.')
+@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-o', '--output', type=str,
               help='Google PubSub topic path e.g. projects/your-project/topics/ethereum_blockchain. '
                    'If not specified will print to console')
-@click.option('-s', '--start-block', default=None, type=int, help='Start block')
-@click.option('-e', '--entity-types', default=','.join(EntityType.ALL_FOR_INFURA), type=str,
+@click.option('-s', '--start-block', default=None, show_default=True, type=int, help='Start block')
+@click.option('-e', '--entity-types', default=','.join(EntityType.ALL_FOR_INFURA), show_default=True, type=str,
               help='The list of entity types to export.')
-@click.option('--period-seconds', default=10, type=int, help='How many seconds to sleep between syncs')
-@click.option('-b', '--batch-size', default=10, type=int, help='How many blocks to batch in single request')
-@click.option('-B', '--block-batch-size', default=1, type=int, help='How many blocks to batch in single sync round')
-@click.option('-w', '--max-workers', default=5, type=int, help='The number of workers')
-@click.option('--log-file', default=None, type=str, help='Log file')
-@click.option('--pid-file', default=None, type=str, help='pid file')
+@click.option('--period-seconds', default=10, show_default=True, type=int, help='How many seconds to sleep between syncs')
+@click.option('-b', '--batch-size', default=10, show_default=True, type=int, help='How many blocks to batch in single request')
+@click.option('-B', '--block-batch-size', default=1, show_default=True, type=int, help='How many blocks to batch in single sync round')
+@click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The number of workers')
+@click.option('--log-file', default=None, show_default=True, type=str, help='Log file')
+@click.option('--pid-file', default=None, show_default=True, type=str, help='pid file')
 def stream(last_synced_block_file, lag, provider_uri, output, start_block, entity_types,
            period_seconds=10, batch_size=2, block_batch_size=10, max_workers=5, log_file=None, pid_file=None):
     """Streams all data types to console or Google Pub/Sub."""


### PR DESCRIPTION
`ethereumetl export_blocks_and_transactions --help` will output:

```
Usage: ethereumetl.py export_blocks_and_transactions [OPTIONS]

  Exports blocks and transactions.

Options:
  -s, --start-block INTEGER   Start block  [default: 0]
  -e, --end-block INTEGER     End block  [required]
  -b, --batch-size INTEGER    The number of blocks to export at a time.
                              [default: 100]
  -p, --provider-uri TEXT     The URI of the web3 provider e.g.
                              file://$HOME/Library/Ethereum/geth.ipc or
                              https://mainnet.infura.io  [default:
                              https://mainnet.infura.io]
  -w, --max-workers INTEGER   The maximum number of workers.  [default: 5]
  --blocks-output TEXT        The output file for blocks. If not provided
                              blocks will not be exported. Use "-" for stdout
  --transactions-output TEXT  The output file for transactions. If not
                              provided transactions will not be exported. Use
                              "-" for stdout
  -c, --chain TEXT            The chain network to connect to.  [default:
                              ethereum]
  -h, --help                  Show this message and exit.
```