### PR TITLE
EIP1559 fields

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ gas_limit         | bigint             |
 gas_used          | bigint             |
 timestamp         | bigint             |
 transaction_count | bigint             |
-baseFeePerGas     | bigint             |
+base_fee_per_gas     | bigint             |
 
 ---
 
@@ -42,6 +42,9 @@ gas              | bigint      |
 gas_price        | bigint      |
 input            | hex_string  |
 block_timestamp  | bigint      |
+max_fee_per_gas  | bigint      |
+max_priority_fee_per_gas | bigint |
+transaction_type | bigint |
 
 ---
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,6 +22,7 @@ gas_limit         | bigint             |
 gas_used          | bigint             |
 timestamp         | bigint             |
 transaction_count | bigint             |
+baseFeePerGas     | bigint             |
 
 ---
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -75,6 +75,7 @@ gas_used                     | bigint      |
 contract_address             | address     |
 root                         | hex_string  |
 status                       | bigint      |
+effective_gas_price          | bigint      |
 
 ---
 

--- a/ethereumetl/domain/block.py
+++ b/ethereumetl/domain/block.py
@@ -43,3 +43,4 @@ class EthBlock(object):
 
         self.transactions = []
         self.transaction_count = 0
+        self.baseFeePerGas = 0

--- a/ethereumetl/domain/block.py
+++ b/ethereumetl/domain/block.py
@@ -43,4 +43,4 @@ class EthBlock(object):
 
         self.transactions = []
         self.transaction_count = 0
-        self.baseFeePerGas = 0
+        self.base_fee_per_gas = 0

--- a/ethereumetl/domain/receipt.py
+++ b/ethereumetl/domain/receipt.py
@@ -33,3 +33,4 @@ class EthReceipt(object):
         self.logs = []
         self.root = None
         self.status = None
+        self.effective_gas_price = None

--- a/ethereumetl/domain/transaction.py
+++ b/ethereumetl/domain/transaction.py
@@ -34,6 +34,6 @@ class EthTransaction(object):
         self.gas = None
         self.gas_price = None
         self.input = None
-        self.maxFeePerGas = None
-        self.maxPriorityFeePerGas = None
-        self.type = None
+        self.max_fee_per_gas = None
+        self.max_priority_fee_per_gas = None
+        self.transaction_type = None

--- a/ethereumetl/domain/transaction.py
+++ b/ethereumetl/domain/transaction.py
@@ -34,3 +34,6 @@ class EthTransaction(object):
         self.gas = None
         self.gas_price = None
         self.input = None
+        self.maxFeePerGas = None
+        self.maxPriorityFeePerGas = None
+        self.type = None

--- a/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -41,7 +41,8 @@ BLOCK_FIELDS_TO_EXPORT = [
     'gas_limit',
     'gas_used',
     'timestamp',
-    'transaction_count'
+    'transaction_count',
+    'baseFeePerGas'
 ]
 
 TRANSACTION_FIELDS_TO_EXPORT = [

--- a/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -57,7 +57,10 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'gas',
     'gas_price',
     'input',
-    'block_timestamp'
+    'block_timestamp',
+    'maxFeePerGas',
+    'maxPriorityFeePerGas',
+    'transaction_type'
 ]
 
 

--- a/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
+++ b/ethereumetl/jobs/exporters/blocks_and_transactions_item_exporter.py
@@ -42,7 +42,7 @@ BLOCK_FIELDS_TO_EXPORT = [
     'gas_used',
     'timestamp',
     'transaction_count',
-    'baseFeePerGas'
+    'base_fee_per_gas'
 ]
 
 TRANSACTION_FIELDS_TO_EXPORT = [
@@ -58,8 +58,8 @@ TRANSACTION_FIELDS_TO_EXPORT = [
     'gas_price',
     'input',
     'block_timestamp',
-    'maxFeePerGas',
-    'maxPriorityFeePerGas',
+    'max_fee_per_gas',
+    'max_priority_fee_per_gas',
     'transaction_type'
 ]
 

--- a/ethereumetl/jobs/exporters/receipts_and_logs_item_exporter.py
+++ b/ethereumetl/jobs/exporters/receipts_and_logs_item_exporter.py
@@ -32,7 +32,8 @@ RECEIPT_FIELDS_TO_EXPORT = [
     'gas_used',
     'contract_address',
     'root',
-    'status'
+    'status',
+    'effective_gas_price'
 ]
 
 LOG_FIELDS_TO_EXPORT = [

--- a/ethereumetl/mappers/block_mapper.py
+++ b/ethereumetl/mappers/block_mapper.py
@@ -52,6 +52,7 @@ class EthBlockMapper(object):
         block.gas_limit = hex_to_dec(json_dict.get('gasLimit'))
         block.gas_used = hex_to_dec(json_dict.get('gasUsed'))
         block.timestamp = hex_to_dec(json_dict.get('timestamp'))
+        block.baseFeePerGas = hex_to_dec(json_dict.get('baseFeePerGas'))
 
         if 'transactions' in json_dict:
             block.transactions = [
@@ -85,4 +86,5 @@ class EthBlockMapper(object):
             'gas_used': block.gas_used,
             'timestamp': block.timestamp,
             'transaction_count': block.transaction_count,
+            'baseFeePerGas': block.baseFeePerGas
         }

--- a/ethereumetl/mappers/block_mapper.py
+++ b/ethereumetl/mappers/block_mapper.py
@@ -52,7 +52,7 @@ class EthBlockMapper(object):
         block.gas_limit = hex_to_dec(json_dict.get('gasLimit'))
         block.gas_used = hex_to_dec(json_dict.get('gasUsed'))
         block.timestamp = hex_to_dec(json_dict.get('timestamp'))
-        block.baseFeePerGas = hex_to_dec(json_dict.get('baseFeePerGas'))
+        block.base_fee_per_gas = hex_to_dec(json_dict.get('baseFeePerGas'))
 
         if 'transactions' in json_dict:
             block.transactions = [
@@ -86,5 +86,5 @@ class EthBlockMapper(object):
             'gas_used': block.gas_used,
             'timestamp': block.timestamp,
             'transaction_count': block.transaction_count,
-            'baseFeePerGas': block.baseFeePerGas
+            'base_fee_per_gas': block.base_fee_per_gas
         }

--- a/ethereumetl/mappers/receipt_mapper.py
+++ b/ethereumetl/mappers/receipt_mapper.py
@@ -48,6 +48,8 @@ class EthReceiptMapper(object):
         receipt.root = json_dict.get('root')
         receipt.status = hex_to_dec(json_dict.get('status'))
 
+        receipt.effective_gas_price = hex_to_dec(json_dict.get('effectiveGasPrice'))
+
         if 'logs' in json_dict:
             receipt.logs = [
                 self.receipt_log_mapper.json_dict_to_receipt_log(log) for log in json_dict['logs']
@@ -66,5 +68,6 @@ class EthReceiptMapper(object):
             'gas_used': receipt.gas_used,
             'contract_address': receipt.contract_address,
             'root': receipt.root,
-            'status': receipt.status
+            'status': receipt.status,
+            'effective_gas_price': receipt.effective_gas_price
         }

--- a/ethereumetl/mappers/transaction_mapper.py
+++ b/ethereumetl/mappers/transaction_mapper.py
@@ -40,9 +40,9 @@ class EthTransactionMapper(object):
         transaction.gas = hex_to_dec(json_dict.get('gas'))
         transaction.gas_price = hex_to_dec(json_dict.get('gasPrice'))
         transaction.input = json_dict.get('input')
-        transaction.maxFeePerGas = json_dict.get('maxFeePerGas')
-        transaction.maxPriorityFeePerGas = json_dict.get('maxPriorityFeePerGas')
-        transaction.type = hex_to_dec(json_dict.get('type'))
+        transaction.max_fee_per_gas = json_dict.get('maxFeePerGas')
+        transaction.max_priority_fee_per_gas = json_dict.get('maxPriorityFeePerGas')
+        transaction.transaction_type = hex_to_dec(json_dict.get('type'))
         return transaction
 
     def transaction_to_dict(self, transaction):
@@ -60,7 +60,7 @@ class EthTransactionMapper(object):
             'gas': transaction.gas,
             'gas_price': transaction.gas_price,
             'input': transaction.input,
-            'maxFeePerGas': transaction.maxFeePerGas,
-            'maxPriorityFeePerGas': transaction.maxPriorityFeePerGas,
-            'transaction_type': transaction.type
+            'max_fee_per_gas': transaction.max_fee_per_gas,
+            'max_priority_fee_per_gas': transaction.max_priority_fee_per_gas,
+            'transaction_type': transaction.transaction_type
         }

--- a/ethereumetl/mappers/transaction_mapper.py
+++ b/ethereumetl/mappers/transaction_mapper.py
@@ -40,6 +40,9 @@ class EthTransactionMapper(object):
         transaction.gas = hex_to_dec(json_dict.get('gas'))
         transaction.gas_price = hex_to_dec(json_dict.get('gasPrice'))
         transaction.input = json_dict.get('input')
+        transaction.maxFeePerGas = json_dict.get('maxFeePerGas')
+        transaction.maxPriorityFeePerGas = json_dict.get('maxPriorityFeePerGas')
+        transaction.type = hex_to_dec(json_dict.get('type'))
         return transaction
 
     def transaction_to_dict(self, transaction):
@@ -57,4 +60,7 @@ class EthTransactionMapper(object):
             'gas': transaction.gas,
             'gas_price': transaction.gas_price,
             'input': transaction.input,
+            'maxFeePerGas': transaction.maxFeePerGas,
+            'maxPriorityFeePerGas': transaction.maxPriorityFeePerGas,
+            'transaction_type': transaction.type
         }

--- a/ethereumetl/mappers/transaction_mapper.py
+++ b/ethereumetl/mappers/transaction_mapper.py
@@ -40,8 +40,8 @@ class EthTransactionMapper(object):
         transaction.gas = hex_to_dec(json_dict.get('gas'))
         transaction.gas_price = hex_to_dec(json_dict.get('gasPrice'))
         transaction.input = json_dict.get('input')
-        transaction.max_fee_per_gas = json_dict.get('maxFeePerGas')
-        transaction.max_priority_fee_per_gas = json_dict.get('maxPriorityFeePerGas')
+        transaction.max_fee_per_gas = hex_to_dec(json_dict.get('maxFeePerGas'))
+        transaction.max_priority_fee_per_gas = hex_to_dec(json_dict.get('maxPriorityFeePerGas'))
         transaction.transaction_type = hex_to_dec(json_dict.get('type'))
         return transaction
 

--- a/ethereumetl/streaming/enrich.py
+++ b/ethereumetl/streaming/enrich.py
@@ -73,14 +73,17 @@ def enrich_transactions(transactions, receipts):
             'input',
             'block_timestamp',
             'block_number',
-            'block_hash'
+            'block_hash',
+            'max_fee_per_gas',
+            'max_priority_fee_per_gas'
         ],
         right_fields=[
             ('cumulative_gas_used', 'receipt_cumulative_gas_used'),
             ('gas_used', 'receipt_gas_used'),
             ('contract_address', 'receipt_contract_address'),
             ('root', 'receipt_root'),
-            ('status', 'receipt_status')
+            ('status', 'receipt_status'),
+            ('effective_gas_price', 'effective_gas_price')
         ]))
 
     if len(result) != len(transactions):

--- a/ethereumetl/streaming/enrich.py
+++ b/ethereumetl/streaming/enrich.py
@@ -75,7 +75,8 @@ def enrich_transactions(transactions, receipts):
             'block_number',
             'block_hash',
             'max_fee_per_gas',
-            'max_priority_fee_per_gas'
+            'max_priority_fee_per_gas',
+            'transaction_type'
         ],
         right_fields=[
             ('cumulative_gas_used', 'receipt_cumulative_gas_used'),


### PR DESCRIPTION
Add new transaction and block fields related to [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md):
* `base_fee_per_gas` (block) - base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (block gas limit divided by elasticity multiplier) of parent block.
* `max_fee_per_gas` (tx) - total fee which covers both the priority fee and the block's network fee per gas
* `max_priority_fee_per_gas` (tx) - maximum fee per gas tx senders are willing to give to miners to incentivize them to include their transaction 
* `transaction_type` (tx) - an envelope for future transaction types
* `effective_gas_price` (receipt) - a replacement for `gasUsed` field