### PR TITLE
adds support for non-mainnet in etl stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ coverage.xml
 .venv
 venv/
 ENV/
+
+# etl
+/last_synced_block.txt

--- a/ethereumetl/streaming/eth_streamer_adapter.py
+++ b/ethereumetl/streaming/eth_streamer_adapter.py
@@ -15,6 +15,7 @@ from ethereumetl.streaming.eth_item_id_calculator import EthItemIdCalculator
 from ethereumetl.streaming.eth_item_timestamp_calculator import EthItemTimestampCalculator
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from web3 import Web3
+from web3.middleware import geth_poa_middleware
 
 
 class EthStreamerAdapter:
@@ -37,7 +38,9 @@ class EthStreamerAdapter:
         self.item_exporter.open()
 
     def get_current_block_number(self):
-        return int(Web3(self.batch_web3_provider).eth.getBlock("latest").number)
+        w3 = Web3(self.batch_web3_provider)
+        w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+        return int(w3.eth.getBlock("latest").number)
 
     def export_all(self, start_block, end_block):
         # Export blocks and transactions


### PR DESCRIPTION
relates #178

DEMO on ronin network, an eth sidechain. Notice that latest block can now be read, thanks to middleware injection.
```
2021-08-12 19:24:34,321 - ProgressLogger [INFO] - Started work. Items to process: 1.
2021-08-12 19:24:34,375 - ProgressLogger [INFO] - 1 items processed. Progress is 100%.
2021-08-12 19:24:34,375 - ProgressLogger [INFO] - Finished work. Total items processed: 1. Took 0:00:00.054600.
2021-08-12 19:24:34,376 - ProgressLogger [INFO] - Started work.
2021-08-12 19:24:34,376 - ProgressLogger [INFO] - Finished work. Total items processed: 0. Took 0:00:00.000169.
2021-08-12 19:24:34,376 - ProgressLogger [INFO] - Started work.
2021-08-12 19:24:34,376 - ProgressLogger [INFO] - Finished work. Total items processed: 0. Took 0:00:00.000143.
```