### PR TITLE
Contract Function Signatures: Look at all blocks

### DIFF
--- a/ethereumetl/service/eth_contract_service.py
+++ b/ethereumetl/service/eth_contract_service.py
@@ -33,10 +33,12 @@ class EthContractService:
             evm_code.disassemble(bytecode)
             basic_blocks = evm_code.basicblocks
             if basic_blocks and len(basic_blocks) > 0:
-                init_block = basic_blocks[0]
-                instructions = init_block.instructions
-                push4_instructions = [inst for inst in instructions if inst.name == 'PUSH4']
-                return sorted(list(set('0x' + inst.operand for inst in push4_instructions)))
+                push4_instructions = set()
+                for block in basic_blocks:
+                    for inst in block.instructions:
+                        if inst.name == 'PUSH4':
+                            push4_instructions.add('0x' + inst.operand)
+                return sorted(list(push4_instructions))
             else:
                 return []
         else:


### PR DESCRIPTION
## Issue
Example contract https://etherscan.io/address/0x1c6178ae715ce8e91812779c6486ee53243abd41 is not marked as ERC20, even though it's function signatures should match:
```
SELECT *
FROM `bigquery-public-data.crypto_ethereum.contracts`
WHERE address = '0x1c6178ae715ce8e91812779c6486ee53243abd41'
```

The bytecode, however, does look like it has all of the correct signatures: https://etherscan.io/bytecode-decompiler?a=0x1c6178ae715ce8e91812779c6486ee53243abd41

I wasn't sure why we were only looking at the first block of instructions, but in the cases I tested, it seems like there can be file signatures in subsequent blocks. Might be missing something though!

## Testing
```
echo "0x1c6178ae715ce8e91812779c6486ee53243abd41" >> contracts_addresses_test.csv
ethereumetl export_contracts --contract-addresses contracts_addresses_test.csv -o contracts.csv -w 3 -p file:///mnt/disks/ssds/geth/geth.ipc
cat contracts.csv

0x1c6178ae715ce8e91812779c6486ee53243abd41,<removed for brevity>,"0x061c82d0,0x06fdde03,0x095ea7b3,0x13114a9d,0x15ab88c9,0x178ef307,0x18160ddd,0x20b9588c,0x23b872dd,0x2cde6081,0x2d838119,0x313ce567,0x3685d419,0x39509351,0x3b124fe7,0x3bd5d173,0x437823ec,0x4549b039,0x4a74bb02,0x4dfefc4b,0x52390c02,0x5342acb4,0x6b455243,0x6bc87c3a,0x70a08231,0x715018a6,0x76e2b7ab,0x77e5006f,0x791ac947,0x7d1db4a5,0x8187f516,0x862a4bf2,0x88f82020,0x8da5cb5b,0x8ee88c53,0x95d89b41,0xa457c2d7,0xa4d66daf,0xa69df4b5,0xa9059cbb,0xad5c4648,0xb6c52324,0xb8c9d25c,0xc0d78655,0xc21ebd07,0xc49b9a80,0xd543dbeb,0xdd467064,0xdd62ed3e,0xea2f0b37,0xf2fde38b,0xf305d719,0xffffffff",True,False,
```

(of note: ERC20 column is True now, and we get a lot more function signatures than before)