### PR TITLE
Adds Aws S3 Adapter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*.csv
+*.json
+*envvars.sh*
+last_block_synced.txt
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.6
-MAINTAINER Evgeny Medvedev <evge.medvedev@gmail.com>
+FROM --platform=linux/amd64 python:3.8
 ENV PROJECT_DIR=ethereum-etl
+ENV PROVIDER_URI=https://
 
 RUN mkdir /$PROJECT_DIR
 WORKDIR /$PROJECT_DIR

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: venv build-image
+
+VENV_NAME=venv
+BRANCH_NAME_SANITIZED=$(subst /,-,$(BRANCH_NAME))
+WORKSPACE_DIR=$(subst @,-,$(notdir ${PWD}))
+DOCKER_PROJECT_NAME=""
+IMAGE_TAG=ethereum-etl:latest
+AWS_REGION=""
+AWS_ACCOUNT=""
+
+build:
+	docker build -t $(IMAGE_TAG) . -f Dockerfile
+
+venv:
+	virtualenv -p python3.7 $(VENV_NAME) && \
+	. $(VENV_NAME)/bin/activate && \
+	pip install -r requirements.txt
+
+build-image:
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com && \
+	docker build -t $(IMAGE_TAG) . -f Dockerfile && \
+  docker tag $(IMAGE_TAG) $(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_TAG)
+
+# Push image to ECR
+push: build-image
+	docker push $(AWS_ACCOUNT).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -103,13 +103,15 @@ For the latest version, check out the repo and call
         > docker run -v $HOME/output:/ethereum-etl/output ethereum-etl:latest export_all -s 0 -e 5499999 -b 100000 -p https://mainnet.infura.io
         > docker run -v $HOME/output:/ethereum-etl/output ethereum-etl:latest export_all -s 2018-01-01 -e 2018-01-01 -p https://mainnet.infura.io
 
-4. Run streaming to console or Pub/Sub
+4. Run streaming to console or Pub/Sub or Aws S3
 
         > docker build -t ethereum-etl:latest -f Dockerfile .
         > echo "Stream to console"
         > docker run ethereum-etl:latest stream --start-block 500000 --log-file log.txt
         > echo "Stream to Pub/Sub"
         > docker run -v /path_to_credentials_file/:/ethereum-etl/ --env GOOGLE_APPLICATION_CREDENTIALS=/ethereum-etl/credentials_file.json ethereum-etl:latest stream --start-block 500000 --output projects/<your-project>/topics/crypto_ethereum
+        > echo "Stream to S3"
+        > docker run --env AWS_ACCESS_KEY="" AWS_SECRET_KEY="" ethereum-etl:latest stream --start-block 500000 --output s3://bucket --env prod --chain ethereum
 
 ## Projects using Ethereum ETL
 * [Google](https://goo.gl/oY5BCQ) - Public BigQuery Ethereum datasets

--- a/blockchainetl/jobs/exporters/s3_item_exporter.py
+++ b/blockchainetl/jobs/exporters/s3_item_exporter.py
@@ -1,0 +1,87 @@
+import collections
+import os, sys
+import logging
+import boto3
+from blockchainetl.jobs.exporters.composite_item_exporter import CompositeItemExporter
+from blockchainetl.jobs.exporters.converters.composite_item_converter import CompositeItemConverter
+from blockchainetl.file_utils import get_file_handle, close_silently
+from datetime import datetime
+import csv
+import json
+
+from uuid import uuid4
+
+class S3ItemExporter(CompositeItemExporter):
+
+    def __init__(self, filename_mapping=None, bucket=None, converters=(), environment='dev', chain='ethereum'):
+        self.filename_mapping = {
+                'block': 'blocks.csv',
+                'transaction': 'transactions.csv',
+                'log': 'logs.json',
+                'token_transfer': 'token_transfers.csv',
+                'trace': 'traces.csv',
+                'contract': 'contracts.csv',
+                'token': 'tokens.csv'
+                }
+        self.field_mapping = {}
+        self.file_mapping = {}
+        self.exporter_mapping = {}
+        self.counter_mapping = {}
+        self.bucket = bucket
+        self.converter = CompositeItemConverter(converters)
+        self.logger = logging.getLogger('S3ItemExporter')
+        self.s3 = boto3.client('s3')
+        self.ENVIRONMENT = environment
+        self.CHAIN = chain
+
+
+    def upload(self, location, filename, type, block_date, item_id):
+            self.s3.upload_file(filename, location, "data/{}/{}/{}/block_date={}/{}".format(self.ENVIRONMENT, self.CHAIN, filename.split('.')[0], block_date, item_id))
+
+    def export_items(self, items):
+        for item in items:
+            self.export_item(item)
+        self.upload_to_s3()
+
+    def convert_items(self, items):
+        for item in items:
+            yield self.converter.convert_item(item)
+
+    def extract_date_from_file(self, file):
+        with open(file, 'r') as f:
+            rows = []
+            if file.endswith('csv'):
+                csv.field_size_limit(sys.maxsize)
+                reader = csv.DictReader(f, delimiter=",")
+                next(reader)
+                for row in reader:
+                    rows.append(row.get('item_timestamp'))
+            elif file.endswith('json'):
+                for i in f:
+                    data = json.loads(i)
+                    rows.append(data.get('item_timestamp'))
+
+            minimus = min(rows, key=lambda x: datetime.strptime(x.split('T')[0], '%Y-%m-%d'))
+            return minimus.split('T')[0]
+
+    def close(self):
+        self.upload_to_s3()
+        for item_type, file in self.file_mapping.items():
+            close_silently(file)
+
+    def flush(self, file):
+        os.remove(file.name)
+        from pathlib import Path
+        Path(file.name).touch()
+        return True
+
+    def upload_to_s3(self):
+        for item_type, file in self.file_mapping.items():
+            counter = self.counter_mapping[item_type]
+            if counter is not None and (counter.increment() - 1) > 0 and (os.stat(file.name).st_size > 0):
+                self.logger.info('{} items exported: {}'.format(item_type, counter.increment() - 1))
+                self.upload(self.bucket, file.name, item_type, self.extract_date_from_file(file.name), str(uuid4()) + '_' + file.name)
+                self.logger.info('Uploaded {} to S3'.format(item_type))
+                self.flush(file)
+                self.logger.info('Flushed {} file'.format(item_type))
+        self.open()

--- a/ethereumetl/cli/stream.py
+++ b/ethereumetl/cli/stream.py
@@ -49,9 +49,11 @@ from ethereumetl.thread_local_proxy import ThreadLocalProxy
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The number of workers')
 @click.option('--log-file', default=None, show_default=True, type=str, help='Log file')
 @click.option('--pid-file', default=None, show_default=True, type=str, help='pid file')
+@click.option('--environment', default='dev', show_default=True, type=str, help='Environmet: dev / prod')
+@click.option('--chain', default='ethereum', show_default=True, type=str, help='Blockchain')
 def stream(last_synced_block_file, lag, provider_uri, output, start_block, entity_types,
-           period_seconds=10, batch_size=2, block_batch_size=10, max_workers=5, log_file=None, pid_file=None):
-    """Streams all data types to console or Google Pub/Sub."""
+           period_seconds=10, batch_size=2, block_batch_size=10, max_workers=5, log_file=None, pid_file=None, environment=None, chain=None):
+    """Streams all data types to console or Google Pub/Sub or AWS S3"""
     configure_logging(log_file)
     configure_signals()
     entity_types = parse_entity_types(entity_types)
@@ -67,7 +69,7 @@ def stream(last_synced_block_file, lag, provider_uri, output, start_block, entit
 
     streamer_adapter = EthStreamerAdapter(
         batch_web3_provider=ThreadLocalProxy(lambda: get_provider_from_uri(provider_uri, batch=True)),
-        item_exporter=create_item_exporter(output),
+        item_exporter=create_item_exporter(output, environment=environment, chain=chain),
         batch_size=batch_size,
         max_workers=max_workers,
         entity_types=entity_types

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             'google-cloud-pubsub==0.39.1',
             'sqlalchemy==1.3.13',
             'pg8000==1.13.2',
+            'boto3==1.18.11',
         ],
         'dev': [
             'pytest~=4.3.0'


### PR DESCRIPTION
# TL;DR
Adds support for Amazon S3

## Synopsis
This extension allows for streaming files from the ETL app directly to aws s3 in a date partitioned fashion so that they can be automatically ingested in Hive / Spark (even databricks parquet delta tables - this is what I personally use it for). There is also a Makefile for easy building and pushing to `aws ecr`.  
There are no tests included in the PR but this has code been tested in production already at different Web3 companies :trollface: 

## Usage 
Simply use the `s3://` root path when passing the `--output` flag and the output will be automatically routed to s3.
## Requirements
`boto3` and AWS keys in the env (docker or not). 
### Example 
```bash
docker run --env AWS_ACCESS_KEY="" AWS_SECRET_KEY="" ethereum-etl:latest stream --start-block 12345678 --output s3://$your-aws-bucket --environment prod --chain ethereum
```