### PR TITLE
Transfer extractor : fix string compare bug by switching to case insensitive string comparison.

### DIFF
--- a/ethereumetl/service/token_transfer_extractor.py
+++ b/ethereumetl/service/token_transfer_extractor.py
@@ -40,7 +40,7 @@ class EthTokenTransferExtractor(object):
             # This is normal, topics can be empty for anonymous events
             return None
 
-        if topics[0] == TRANSFER_EVENT_TOPIC:
+        if (topics[0]).casefold() == TRANSFER_EVENT_TOPIC:
             # Handle unindexed event fields
             topics_with_data = topics + split_to_words(receipt_log.data)
             # if the number of topics and fields in data part != 4, then it's a weird event


### PR DESCRIPTION
Some nodes as a service don’t return the result in lowercase but use the ᴇɪᴘ-55 checksum format or in uppercase.
This results in some transfers being rejected whereas the topic match.

*I had a hard time finding why a lot of transfers were missing in my case.*