### PR TITLE
schemas/aws/parquet: updated to reflect BigQuery schema

### DIFF
--- a/schemas/aws/parquet/parquet_blocks.sql
+++ b/schemas/aws/parquet/parquet_blocks.sql
@@ -1,4 +1,5 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS parquet_blocks (
+    timestamp TIMESTAMP,
     number BIGINT,
     hash STRING,
     parent_hash STRING,
@@ -15,11 +16,9 @@ CREATE EXTERNAL TABLE IF NOT EXISTS parquet_blocks (
     extra_data STRING,
     gas_limit BIGINT,
     gas_used BIGINT,
-    timestamp BIGINT,
-    transaction_count BIGINT
+    transaction_count BIGINT,
+    base_fee_per_gas BIGINT
 )
 PARTITIONED BY (start_block BIGINT, end_block BIGINT)
 STORED AS PARQUET
 LOCATION 's3://<your_bucket>/ethereumetl/parquet/blocks';
-
-MSCK REPAIR TABLE parquet_blocks;

--- a/schemas/aws/parquet/parquet_token_transfers.sql
+++ b/schemas/aws/parquet/parquet_token_transfers.sql
@@ -2,13 +2,13 @@ CREATE EXTERNAL TABLE IF NOT EXISTS parquet_token_transfers (
     token_address STRING,
     from_address STRING,
     to_address STRING,
-    value DECIMAL(38,0),
+    value STRING,
     transaction_hash STRING,
     log_index BIGINT,
-    block_number BIGINT
+    block_timestamp TIMESTAMP,
+    block_number BIGINT,
+    block_hash STRING
 )
 PARTITIONED BY (start_block BIGINT, end_block BIGINT)
 STORED AS PARQUET
 LOCATION 's3://<your_bucket>/ethereumetl/parquet/token_transfers';
-
-MSCK REPAIR TABLE parquet_token_transfers;

--- a/schemas/aws/parquet/parquet_transactions.sql
+++ b/schemas/aws/parquet/parquet_transactions.sql
@@ -1,18 +1,25 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS parquet_transactions (
     hash STRING,
     nonce BIGINT,
-    block_hash STRING,
-    block_number BIGINT,
     transaction_index BIGINT,
     from_address STRING,
     to_address STRING,
     value DECIMAL(38,0),
     gas BIGINT,
     gas_price BIGINT,
-    input STRING
+    input STRING,
+    receipt_cumulative_gas_used BIGINT,
+    receipt_gas_used BIGINT,
+    receipt_contract_address STRING,
+    receipt_root STRING,
+    receipt_status BIGINT,
+    block_timestamp TIMESTAMP,
+    block_number INTEGER,
+    block_hash STRING,
+    max_fee_per_gas BIGINT,
+    max_priority_fee_per_gas BIGINT,
+    transaction_type BIGINT,
+    receipt_effective_gas_price BIGINT
 )
-PARTITIONED BY (start_block BIGINT, end_block BIGINT)
 STORED AS PARQUET
 LOCATION 's3://<your_bucket>/ethereumetl/parquet/transactions';
-
-MSCK REPAIR TABLE parquet_transactions;


### PR DESCRIPTION
I have used this schemas to unload BigQuery tables (transactions, blocks and token_transfers) into AWS S3. They are in sync with the current BigQuery schemas.