### PR TITLE
Bugfix: Ignore ContractLogicError raised by Web3.py

### DIFF
--- a/ethereumetl/service/eth_token_service.py
+++ b/ethereumetl/service/eth_token_service.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 import logging
 
-from web3.exceptions import BadFunctionCallOutput
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
 from ethereumetl.domain.token import EthToken
 from ethereumetl.erc20_abi import ERC20_ABI, ERC20_ABI_ALTERNATIVE_1
@@ -82,7 +82,7 @@ class EthTokenService(object):
         # OverflowError exception happens if the return type of the function doesn't match the expected type
         result = call_contract_function(
             func=func,
-            ignore_errors=(BadFunctionCallOutput, OverflowError, ValueError),
+            ignore_errors=(BadFunctionCallOutput, ContractLogicError, OverflowError, ValueError),
             default_value=None)
 
         if self._function_call_result_transformer is not None:


### PR DESCRIPTION
Streaming a recent blockchain contract, I've received the error below, and the streaming got stuck in a retry loop.
As per issue #143, it should be safe to ignore.

Further explanation:

The contract that raises the error is this one: https://etherscan.io/address/0x60ff650143d3fcd98585ce60a9a622f255ce5687 

Not sure if other people had this problem while streaming data. It appears that sometimes the code hangs in a retry loop, and sometimes it does not.

The modification that breaks the code happened [two years ago](https://github.com/ethereum/web3.py/pull/1585/files) in the `Web3.py` dependency after the `EthTokenService` was written, and the issue was closed.

```
2022-07-25 21:28:01,357 - root [INFO] - Current block 15214113, target block 15138410, last synced block 15138409, blocks to sync 1
2022-07-25 21:28:01,357 - ProgressLogger [INFO] - Started work. Items to process: 1.
2022-07-25 21:28:01,474 - ProgressLogger [INFO] - 1 items processed. Progress is 100%.
2022-07-25 21:28:01,475 - ProgressLogger [INFO] - Finished work. Total items processed: 1. Took 0:00:00.117752.
2022-07-25 21:28:01,475 - ProgressLogger [INFO] - Started work.
2022-07-25 21:28:01,714 - ProgressLogger [INFO] - Finished work. Total items processed: 110. Took 0:00:00.239227.
2022-07-25 21:28:01,715 - ProgressLogger [INFO] - Started work.
2022-07-25 21:28:01,722 - ProgressLogger [INFO] - Finished work. Total items processed: 82. Took 0:00:00.006437.
2022-07-25 21:28:01,722 - ProgressLogger [INFO] - Started work. Items to process: 1.
2022-07-25 21:28:02,172 - ProgressLogger [INFO] - 1 items processed. Progress is 100%.
2022-07-25 21:28:02,173 - ProgressLogger [INFO] - Finished work. Total items processed: 1. Took 0:00:00.450221.
2022-07-25 21:28:02,173 - ProgressLogger [INFO] - Started work.
2022-07-25 21:28:02,377 - evmdasm.disassembler [ERROR] - invalid instruction: PUSH16
2022-07-25 21:28:02,387 - ProgressLogger [INFO] - Finished work. Total items processed: 274. Took 0:00:00.213509.
2022-07-25 21:28:02,387 - ProgressLogger [INFO] - Started work.
2022-07-25 21:28:02,667 - root [ERROR] - An exception occurred while syncing block data.
Traceback (most recent call last):
  File "/ethereum-etl/blockchainetl/streaming/streamer.py", line 79, in _do_stream
    synced_blocks = self._sync_cycle()
  File "/ethereum-etl/blockchainetl/streaming/streamer.py", line 100, in _sync_cycle
    self.blockchain_streamer_adapter.export_all(self.last_synced_block + 1, target_block)
  File "/ethereum-etl/ethereumetl/streaming/eth_streamer_adapter.py", line 75, in export_all
    tokens = self._extract_tokens(contracts)
  File "/ethereum-etl/ethereumetl/streaming/eth_streamer_adapter.py", line 186, in _extract_tokens
    job.run()
  File "/ethereum-etl/blockchainetl/jobs/base_job.py", line 30, in run
    self._end()
  File "/ethereum-etl/ethereumetl/jobs/export_tokens_job.py", line 56, in _end
    self.batch_work_executor.shutdown()
  File "/ethereum-etl/ethereumetl/executors/batch_work_executor.py", line 97, in shutdown
    self.executor.shutdown()
  File "/ethereum-etl/ethereumetl/executors/fail_safe_executor.py", line 39, in shutdown
    self._check_completed_futures()
  File "/ethereum-etl/ethereumetl/executors/fail_safe_executor.py", line 47, in _check_completed_futures
    future.result()
  File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/ethereum-etl/ethereumetl/executors/batch_work_executor.py", line 63, in _fail_safe_execute
    work_handler(batch)
  File "/ethereum-etl/ethereumetl/jobs/extract_tokens_job.py", line 39, in _export_tokens_from_contracts
    self._export_token(token_address=token['address'], block_number=token['block_number'])
  File "/ethereum-etl/ethereumetl/jobs/export_tokens_job.py", line 50, in _export_token
    token = self.token_service.get_token(token_address)
  File "/ethereum-etl/ethereumetl/service/eth_token_service.py", line 60, in get_token
    decimals = self._get_first_result(contract.functions.decimals(), contract.functions.DECIMALS())
  File "/ethereum-etl/ethereumetl/service/eth_token_service.py", line 74, in _get_first_result
    result = self._call_contract_function(func)
  File "/ethereum-etl/ethereumetl/service/eth_token_service.py", line 86, in _call_contract_function
    default_value=None)
  File "/ethereum-etl/ethereumetl/service/eth_token_service.py", line 121, in call_contract_function
    raise ex
  File "/ethereum-etl/ethereumetl/service/eth_token_service.py", line 113, in call_contract_function
    result = func.call()
  File "/usr/local/lib/python3.7/site-packages/web3/contract.py", line 981, in call
    **self.kwargs
  File "/usr/local/lib/python3.7/site-packages/web3/contract.py", line 1528, in call_contract_function
    state_override=state_override,
  File "/usr/local/lib/python3.7/site-packages/web3/module.py", line 60, in caller
    null_result_formatters)
  File "/usr/local/lib/python3.7/site-packages/web3/manager.py", line 201, in request_blocking
    null_result_formatters)
  File "/usr/local/lib/python3.7/site-packages/web3/manager.py", line 170, in formatted_response
    apply_error_formatters(error_formatters, response)
  File "/usr/local/lib/python3.7/site-packages/web3/manager.py", line 70, in apply_error_formatters
    formatted_resp = pipe(response, error_formatters)
  File "cytoolz/functoolz.pyx", line 666, in cytoolz.functoolz.pipe
  File "cytoolz/functoolz.pyx", line 641, in cytoolz.functoolz.c_pipe
  File "/usr/local/lib/python3.7/site-packages/web3/_utils/method_formatters.py", line 580, in raise_solidity_error_on_revert
    raise ContractLogicError('execution reverted')
web3.exceptions.ContractLogicError: execution reverted
```