### PR TITLE
Remove --ipcapi debug from geth as it was deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://app.travis-ci.com/blockchain-etl/ethereum-etl.svg?branch=develop)](https://travis-ci.com/github/blockchain-etl/ethereum-etl)
 [![Join the chat at https://gitter.im/ethereum-eth](https://badges.gitter.im/ethereum-etl.svg)](https://gitter.im/ethereum-etl/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-blue.svg)](https://t.me/joinchat/GsMpbA3mv1OJ6YMp3T5ORQ)
-[![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/wukrezR)
+[![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/tRKG7zGKtF)
 
 Ethereum ETL lets you convert blockchain data into convenient formats like CSVs and relational databases.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,7 +165,7 @@ You can tune `--batch-size`, `--max-workers` for performance.
 Read [Differences between geth and parity traces.csv](schema.md#differences-between-geth-and-parity-tracescsv)
 
 The API used in this command is not supported by Infura, 
-so you will need a local Geth archive node (`geth --gcmode archive --syncmode full --ipcapi debug`).
+so you will need a local Geth archive node (`geth --gcmode archive --syncmode full`).
 When using rpc, add `--rpc --rpcapi debug` options.
 
 ```bash


### PR DESCRIPTION
The options was deprecated https://github.com/ethereum/go-ethereum/issues/16786 so updating the docs in this PR