### PR TITLE
fix: update uninstall filter

### DIFF
--- a/ethereumetl/jobs/export_origin_job.py
+++ b/ethereumetl/jobs/export_origin_job.py
@@ -112,7 +112,7 @@ class ExportOriginJob(BaseJob):
                     item = self.shop_listing_mapper.product_to_dict(product)
                     self.shop_product_exporter.export_item(item)
 
-            self.web3.eth.uninstallFilter(event_filter.filter_id)
+            self.web3.eth.uninstall_filter(event_filter.filter_id)
 
     def _end(self):
         self.batch_work_executor.shutdown()

--- a/ethereumetl/jobs/export_token_transfers_job.py
+++ b/ethereumetl/jobs/export_token_transfers_job.py
@@ -82,7 +82,7 @@ class ExportTokenTransfersJob(BaseJob):
             if token_transfer is not None:
                 self.item_exporter.export_item(self.token_transfer_mapper.token_transfer_to_dict(token_transfer))
 
-        self.web3.eth.uninstallFilter(event_filter.filter_id)
+        self.web3.eth.uninstall_filter(event_filter.filter_id)
 
     def _end(self):
         self.batch_work_executor.shutdown()


### PR DESCRIPTION
`uninstallFilter` is deprecated as we can see in the following [document](https://web3py.readthedocs.io/en/stable/web3.eth.html#web3.eth.Eth.uninstall_filter).
We should update to `uninstall_filter` instead.
I have ran through pytest and it worked.