### PR TITLE
Bump google-cloud-pubsub version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     extras_require={
         'streaming': [
             'timeout-decorator==0.4.1',
-            'google-cloud-pubsub==2.1.0',
+            'google-cloud-pubsub==2.13.0',
             'google-cloud-storage==1.33.0',
             'kafka-python==2.0.2',
             'sqlalchemy==1.4',


### PR DESCRIPTION
Bump google-cloud-pubsub version to prevent `No module named 'pytz'` https://github.com/googleapis/python-pubsub/issues/474#issuecomment-902117953