### PR TITLE
Change print(data) in Kafka exporter to instead log at the debug level

### DIFF
--- a/blockchainetl/jobs/exporters/kafka_exporter.py
+++ b/blockchainetl/jobs/exporters/kafka_exporter.py
@@ -33,7 +33,7 @@ class KafkaItemExporter:
         item_type = item.get('type')
         if item_type is not None and item_type in self.item_type_to_topic_mapping:
             data = json.dumps(item).encode('utf-8')
-            print(data)
+            logging.debug(data)
             return self.producer.send(self.item_type_to_topic_mapping[item_type], value=data)
         else:
             logging.warning('Topic for item type "{}" is not configured.'.format(item_type))


### PR DESCRIPTION
Replaces `print(data)` with `logging.debug(data)` in the Kafka exporter so all the data doesn't have to be printed out