### PR TITLE
set max field size limit for export token transfers

### DIFF
--- a/ethereumetl/cli/export_token_transfers.py
+++ b/ethereumetl/cli/export_token_transfers.py
@@ -25,6 +25,7 @@ import click
 
 from ethereumetl.web3_utils import build_web3
 
+from ethereumetl.csv_utils import set_max_field_size_limit
 from ethereumetl.jobs.export_token_transfers_job import ExportTokenTransfersJob
 from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_transfers_item_exporter
 from blockchainetl.logging_utils import logging_basic_config
@@ -45,6 +46,7 @@ logging_basic_config()
 @click.option('-t', '--tokens', default=None, show_default=True, type=str, multiple=True, help='The list of token addresses to filter by.')
 def export_token_transfers(start_block, end_block, batch_size, output, max_workers, provider_uri, tokens):
     """Exports ERC20/ERC721 transfers."""
+    set_max_field_size_limit()
     job = ExportTokenTransfersJob(
         start_block=start_block,
         end_block=end_block,


### PR DESCRIPTION
By execute `ethereumetl extract_token_transfers --logs logs.csv --output token_transfers.csv --max-workers 1`, we got error as below.

```python
Traceback (most recent call last):
  File "/usr/bin/ethereumetl", line 33, in <module>
    sys.exit(load_entry_point('ethereum-etl==2.0.6', 'console_scripts', 'ethereumetl')())
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/ethereumetl/cli/extract_token_transfers.py", line 57, in extract_token_transfers
    job.run()
  File "/usr/lib/python3.10/site-packages/blockchainetl/jobs/base_job.py", line 28, in run
    self._export()
  File "/usr/lib/python3.10/site-packages/ethereumetl/jobs/extract_token_transfers_job.py", line 50, in _export
    self.batch_work_executor.execute(self.logs_iterable, self._extract_transfers)
  File "/usr/lib/python3.10/site-packages/ethereumetl/executors/batch_work_executor.py", line 58, in execute
    for batch in dynamic_batch_iterator(work_iterable, lambda: self.batch_size):
  File "/usr/lib/python3.10/site-packages/ethereumetl/utils.py", line 113, in dynamic_batch_iterator
    for item in iterable:
  File "/usr/lib/python3.10/csv.py", line 111, in __next__
    row = next(self.reader)
_csv.Error: field larger than field limit (131072)
```

After call function `set_max_field_size_limit()`, error disappeared.