### PR TITLE
Add *args, **kwargs on create_item_exporter(s) for flexiblility

### DIFF
--- a/ethereumetl/cli/stream.py
+++ b/ethereumetl/cli/stream.py
@@ -53,8 +53,9 @@ from ethereumetl.thread_local_proxy import ThreadLocalProxy
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The number of workers')
 @click.option('--log-file', default=None, show_default=True, type=str, help='Log file')
 @click.option('--pid-file', default=None, show_default=True, type=str, help='pid file')
+@click.option('--topic-prefix', default=None, show_default=True, type=str, help='topic prefix for kafka, pubsub, e.g. blockchain.ethereuem')
 def stream(last_synced_block_file, lag, provider_uri, output, start_block, entity_types,
-           period_seconds=10, batch_size=2, block_batch_size=10, max_workers=5, log_file=None, pid_file=None):
+           period_seconds=10, batch_size=2, block_batch_size=10, max_workers=5, log_file=None, pid_file=None, topic_prefix=None):
     """Streams all data types to console or Google Pub/Sub."""
     configure_logging(log_file)
     configure_signals()
@@ -69,7 +70,7 @@ def stream(last_synced_block_file, lag, provider_uri, output, start_block, entit
 
     streamer_adapter = EthStreamerAdapter(
         batch_web3_provider=ThreadLocalProxy(lambda: get_provider_from_uri(provider_uri, batch=True)),
-        item_exporter=create_item_exporters(output),
+        item_exporter=create_item_exporters(output, topic_prefix=topic_prefix),
         batch_size=batch_size,
         max_workers=max_workers,
         entity_types=entity_types


### PR DESCRIPTION
The reason to add these args is the way item exporter created is always fixed(hard coded). Due to this, if I want to change the topic name in creating Pubsub or Kafka exporter, I have nothing to do except forking the project and changing the topic name in code level. By adding these args, we can avoid this behavior.