### PR TITLE
Upgrade eth-abi lower bound to >=2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         'web3>=5.29,<6',
         'eth-utils==1.10',
-        'eth-abi==2.1.1',
+        'eth-abi>=2.2.0,<3.0.0',
         # TODO: This has to be removed when "ModuleNotFoundError: No module named 'eth_utils.toolz'" is fixed at eth-abi
         'python-dateutil>=2.8.0,<3',
         'click==8.0.4',


### PR DESCRIPTION
Update the eth-abi version based on lastest Web3.py [release](https://github.com/ethereum/web3.py/pull/2743), to make sure internal deprecation changes do not break.
