### PR TITLE
Restrict urllib3 v2 as it breaks the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 dist: xenial
+before_install:
+  - sudo add-apt-repository -y ppa:deadsnakes/ppa
+  - sudo apt-get update
+  - sudo apt-get install -y libssl-dev
 matrix:
   include:
     - python: "3.7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 dist: xenial
-before_install:
-  - sudo add-apt-repository -y ppa:deadsnakes/ppa
-  - sudo apt-get update
-  - sudo apt-get install -y libssl-dev
 matrix:
   include:
     - python: "3.7.2"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'python-dateutil>=2.8.0,<3',
         'click>=8.0.4,<9',
         'ethereum-dasm==0.1.4',
+        'urllib3<2',
         'base58',
         'requests'
     ],


### PR DESCRIPTION
Fixes the error in Travis CI https://app.travis-ci.com/github/blockchain-etl/ethereum-etl/jobs/603030848

```
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/web3/__init__.py", line 9, in <module>
    from web3.main import (
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/_pytest/assertion/rewrite.py", line 296, in load_module
    six.exec_(co, mod.__dict__)
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/web3/main.py", line 87, in <module>
    from web3.manager import (
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/_pytest/assertion/rewrite.py", line 296, in load_module
    six.exec_(co, mod.__dict__)
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/web3/manager.py", line 37, in <module>
    from web3.middleware import (
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/web3/middleware/__init__.py", line 35, in <module>
    from .exception_retry_request import (  # noqa: F401
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/_pytest/assertion/rewrite.py", line 296, in load_module
    six.exec_(co, mod.__dict__)
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/web3/middleware/exception_retry_request.py", line 9, in <module>
    from requests.exceptions import (
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/travis/build/blockchain-etl/ethereum-etl/.tox/py39/lib/python3.9/site-packages/urllib3/__init__.py", line 38, in <module>
    raise ImportError(
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2g  1 Mar 2016. See: https://github.com/urllib3/urllib3/issues/2168
py39: exit 1 (0.90 seconds) /home/travis/build/blockchain-etl/ethereum-etl> pytest pid=4099
.pkg: _exit> python /home/travis/virtualenv/python3.9.6/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py39: FAIL code 1 (27.83=setup[26.92]+cmd[0.90] seconds)
  evaluation failed :( (32.71 seconds)
```

urllib3 v2 requires openssl 1.1.1+ which is not available in xenial image https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html