### PR TITLE
Added hex_to_dec for block nonce field

### DIFF
--- a/ethereumetl/mappers/block_mapper.py
+++ b/ethereumetl/mappers/block_mapper.py
@@ -38,7 +38,7 @@ class EthBlockMapper(object):
         block.number = hex_to_dec(json_dict.get('number'))
         block.hash = json_dict.get('hash')
         block.parent_hash = json_dict.get('parentHash')
-        block.nonce = json_dict.get('nonce')
+        block.nonce = hex_to_dec(json_dict.get('nonce'))
         block.sha3_uncles = json_dict.get('sha3Uncles')
         block.logs_bloom = json_dict.get('logsBloom')
         block.transactions_root = json_dict.get('transactionsRoot')


### PR DESCRIPTION
`EthBlockMapper` in `json_dict_to_block` was missing '`hex_to_dec`' for '`nonce`' field. Added `hex_to_dec`.

At the same time `EthTransactionMapper` does have this transformation
```
        transaction.nonce = hex_to_dec(json_dict.get('nonce'))
```