### PR TITLE
add mesc support

### DIFF
--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -32,7 +32,7 @@ from ethereumetl.web3_utils import build_web3
 from ethereumetl.jobs.export_all_common import export_all_common
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.service.eth_service import EthService
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
@@ -109,7 +109,7 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 @click.option('-e', '--end', required=True, type=str, help='End block/ISO date/Unix time')
 @click.option('-b', '--partition-batch-size', default=10000, show_default=True, type=int,
               help='The number of blocks to export in partition.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-o', '--output-dir', default='output', show_default=True, type=str, help='Output directory, partitioned in Hive style.')

--- a/ethereumetl/cli/export_blocks_and_transactions.py
+++ b/ethereumetl/cli/export_blocks_and_transactions.py
@@ -28,7 +28,7 @@ from ethereumetl.jobs.exporters.blocks_and_transactions_item_exporter import blo
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
@@ -37,7 +37,7 @@ logging_basic_config()
 @click.option('-s', '--start-block', default=0, show_default=True, type=int, help='Start block')
 @click.option('-e', '--end-block', required=True, type=int, help='End block')
 @click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of blocks to export at a time.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')

--- a/ethereumetl/cli/export_contracts.py
+++ b/ethereumetl/cli/export_contracts.py
@@ -29,7 +29,7 @@ from ethereumetl.jobs.exporters.contracts_item_exporter import contracts_item_ex
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
@@ -40,7 +40,7 @@ logging_basic_config()
               help='The file containing contract addresses, one per line.')
 @click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')

--- a/ethereumetl/cli/export_receipts_and_logs.py
+++ b/ethereumetl/cli/export_receipts_and_logs.py
@@ -29,7 +29,7 @@ from ethereumetl.jobs.exporters.receipts_and_logs_item_exporter import receipts_
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
@@ -38,7 +38,7 @@ logging_basic_config()
 @click.option('-b', '--batch-size', default=100, show_default=True, type=int, help='The number of receipts to export at a time.')
 @click.option('-t', '--transaction-hashes', required=True, type=str,
               help='The file containing transaction hashes, one per line.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')

--- a/ethereumetl/cli/export_tokens.py
+++ b/ethereumetl/cli/export_tokens.py
@@ -31,7 +31,7 @@ from ethereumetl.jobs.exporters.tokens_item_exporter import tokens_item_exporter
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.providers.auto import get_provider_from_uri
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
@@ -41,7 +41,7 @@ logging_basic_config()
               help='The file containing token addresses, one per line.')
 @click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')

--- a/ethereumetl/cli/extract_tokens.py
+++ b/ethereumetl/cli/extract_tokens.py
@@ -33,6 +33,7 @@ from ethereumetl.jobs.extract_tokens_job import ExtractTokensJob
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
+from ethereumetl.utils import get_default_provider_uri
 from ethereumetl.web3_utils import build_web3
 
 logging_basic_config()
@@ -40,7 +41,7 @@ logging_basic_config()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-c', '--contracts', type=str, required=True, help='The JSON file containing contracts.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-o', '--output', default='-', show_default=True, type=str, help='The output file. If not specified stdout is used.')

--- a/ethereumetl/cli/get_block_range_for_date.py
+++ b/ethereumetl/cli/get_block_range_for_date.py
@@ -30,13 +30,13 @@ from blockchainetl.file_utils import smart_open
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.service.eth_service import EthService
 from ethereumetl.providers.auto import get_provider_from_uri
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-d', '--date', required=True, type=lambda d: datetime.strptime(d, '%Y-%m-%d'),

--- a/ethereumetl/cli/get_block_range_for_timestamps.py
+++ b/ethereumetl/cli/get_block_range_for_timestamps.py
@@ -29,13 +29,13 @@ from blockchainetl.file_utils import smart_open
 from blockchainetl.logging_utils import logging_basic_config
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.service.eth_service import EthService
-from ethereumetl.utils import check_classic_provider_uri
+from ethereumetl.utils import check_classic_provider_uri, get_default_provider_uri
 
 logging_basic_config()
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-s', '--start-timestamp', required=True, type=int, help='Start unix timestamp, in seconds.')

--- a/ethereumetl/cli/stream.py
+++ b/ethereumetl/cli/stream.py
@@ -29,12 +29,13 @@ from ethereumetl.enumeration.entity_type import EntityType
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.streaming.item_exporter_creator import create_item_exporters
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
+from ethereumetl.utils import get_default_provider_uri
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-l', '--last-synced-block-file', default='last_synced_block.txt', show_default=True, type=str, help='')
 @click.option('--lag', default=0, show_default=True, type=int, help='The number of blocks to lag behind the network.')
-@click.option('-p', '--provider-uri', default='https://mainnet.infura.io', show_default=True, type=str,
+@click.option('-p', '--provider-uri', default=get_default_provider_uri, show_default=True, type=str,
               help='The URI of the web3 provider e.g. '
                    'file://$HOME/Library/Ethereum/geth.ipc or https://mainnet.infura.io')
 @click.option('-o', '--output', type=str,

--- a/ethereumetl/providers/auto.py
+++ b/ethereumetl/providers/auto.py
@@ -23,6 +23,7 @@
 
 from urllib.parse import urlparse
 
+import mesc
 from web3 import IPCProvider, HTTPProvider
 
 from ethereumetl.providers.ipc import BatchIPCProvider
@@ -32,6 +33,15 @@ DEFAULT_TIMEOUT = 60
 
 
 def get_provider_from_uri(uri_string, timeout=DEFAULT_TIMEOUT, batch=False):
+
+    if mesc.is_mesc_enabled():
+        try:
+            endpoint = mesc.get_endpoint_by_query(uri_string, profile='ethereum_etl')
+            if endpoint is not None:
+                uri_string = endpoint['url']
+        except Exception as e:
+            print('MESC configured improperly')
+
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
         if batch:

--- a/ethereumetl/utils.py
+++ b/ethereumetl/utils.py
@@ -24,6 +24,8 @@
 import itertools
 import warnings
 
+import mesc
+
 from ethereumetl.misc.retriable_value_error import RetriableValueError
 
 
@@ -142,3 +144,15 @@ def check_classic_provider_uri(chain, provider_uri):
         warnings.warn("ETC Chain not supported on Infura.io. Using https://ethereumclassic.network instead")
         return 'https://ethereumclassic.network'
     return provider_uri
+
+
+def get_default_provider_uri():
+    if mesc.is_mesc_enabled():
+        try:
+            endpoint = mesc.get_default_endpoint(profile='ethereum_etl')
+            if endpoint is not None:
+                return endpoint['url']
+        except Exception:
+            print('MESC configured improperly')
+
+    return 'https://mainnet.infura.io'

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'web3>=5.29,<6',
         'eth-utils==1.10',
         'eth-abi>=2.2.0,<3.0.0',
+        'mesc==0.2.0',
         # TODO: This has to be removed when "ModuleNotFoundError: No module named 'eth_utils.toolz'" is fixed at eth-abi
         'python-dateutil>=2.8.0,<3',
         'click>=8.0.4,<9',


### PR DESCRIPTION
## What is this?

This is a PR to add [MESC](https://github.com/paradigmxyz/mesc) to ethereum-etl.

MESC is an RPC configuration standard that allows a user to share a single RPC configuration across all of the tools on their system. ethereum-etl does not currently allow for configuring a default rpc provider or configuring separate network-specific defaults. Adopting a standardized approach will increase ethereum-etl's interoperability and make it easier for users to manage multiple endpoints across multiple networks.

More information about MESC can be found in the [MESC docs](https://paradigmxyz.github.io/mesc/).

## Backward Compatibility

MESC is an opt-in standard and this PR integrates it into ethereum-etl in a backward-compatible way. MESC is only used when a user has enabled MESC in their environment. Behavior of ethereum-etl is unchanged for users that have not enabled MESC.

## Behavioral Changes

This PR introduces two behavioral changes to ethereum-etl:

1. If a user has enabled MESC in their environment, use the user's MESC default instead of ethereum-etl's previous default of https://mainnet.infura.io. If a user has not set defaults in their MESC config, ethereum-etl falls back to using https://mainnet.infura.io as the default.

The follow commands are affected:
- `export_all`
- `export_blocks_and_transactions`
- `export_contracts`
- `export_receipts_and_logs`
- `export_tokens`
- `extract_tokens`
- `get_block_range_for_date`
- `get_block_range_for_timestamps`
- `stream`

2. If a user has enabled MESC in their environment, the `-p` / `--provider-uri` argument now allow users to specify providers using 1) an endpoint name, 2) a network name, 3) a chain id, or 4) a URI (as before). For example, each of the following is now allowed:

specify by endpoint name
`export_blocks_and_transactions -p local_goerli ...`

specify by network name
`export_blocks_and_transactions -p goerli ...`

specify by chain id
`export_blocks_and_transactions -p 5 ...`

specify by uri
`export_blocks_and_transactions -p http://localhost:8545 ...`

## Dependency Changes

The [`mesc`](https://github.com/paradigmxyz/mesc/tree/main/python) python implementation has no dependencies and is compatible with python 3.7 through python 3.12.

## How to set up MESC?

There are two basic steps: create a `mesc.json` and set `MESC_PATH` to the path of this file. Details can be found in the MESC [Quickstart Guide](https://paradigmxyz.github.io/mesc/quickstart.html). The setup process can also be performed interactively with the [`mesc`](https://github.com/paradigmxyz/mesc/tree/main/cli) cli tool.

## Why would ethereum-etl integrate MESC?

- **Multi-endpoint UX**: Users will be able to easily choose between various networks and endpoints when exporting data.
- **Easier onboarding**: As soon as a user installs ethereum-etl, they will immediately be able to use it with all of their configured MESC endpoints, no additional configuration needed.
- **Minimize dev maintenance burden**: ethereum-etl will no longer has to maintain code for configuring endpoints, this gets outsourced to MESC.
- **Future-proof metadata**. MESC can store metadata about each endpoint to track things like rate-limits, namespaces, and endpoint groupings. Integrating MESC would give ethereum-etl the ability to easily use this information in the future for new features. 

A longer form discussion of these advantages can be found on the [Why MESC?](https://paradigmxyz.github.io/mesc/why_mesc.html) page of the MESC docs.

## What do you think?

Let me know what you think and if you have any general questions about MESC.
