### PR TITLE
Add Dencun fields to postgres_tables.py

### DIFF
--- a/blockchainetl/jobs/exporters/converters/simple_item_converter.py
+++ b/blockchainetl/jobs/exporters/converters/simple_item_converter.py
@@ -30,8 +30,10 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 
-
 class SimpleItemConverter:
+
+    def __init__(self, field_converters=None):
+        self.field_converters = field_converters
 
     def convert_item(self, item):
         return {
@@ -39,4 +41,7 @@ class SimpleItemConverter:
         }
 
     def convert_field(self, key, value):
-        return value
+        if self.field_converters is not None and key in self.field_converters:
+            return self.field_converters[key](value)
+        else:
+            return value

--- a/ethereumetl/streaming/item_exporter_creator.py
+++ b/ethereumetl/streaming/item_exporter_creator.py
@@ -62,7 +62,11 @@ def create_item_exporter(output):
         from blockchainetl.jobs.exporters.converters.unix_timestamp_item_converter import UnixTimestampItemConverter
         from blockchainetl.jobs.exporters.converters.int_to_decimal_item_converter import IntToDecimalItemConverter
         from blockchainetl.jobs.exporters.converters.list_field_item_converter import ListFieldItemConverter
+        from blockchainetl.jobs.exporters.converters.simple_item_converter import SimpleItemConverter
         from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, TRACES, TOKENS, CONTRACTS
+
+        def array_to_str(val):
+            return ','.join(val) if val is not None else None
 
         item_exporter = PostgresItemExporter(
             output, item_type_to_insert_stmt_mapping={
@@ -74,8 +78,12 @@ def create_item_exporter(output):
                 'token': create_insert_statement_for_table(TOKENS),
                 'contract': create_insert_statement_for_table(CONTRACTS),
             },
-            converters=[UnixTimestampItemConverter(), IntToDecimalItemConverter(),
-                        ListFieldItemConverter('topics', 'topic', fill=4)])
+            converters=[
+                UnixTimestampItemConverter(),
+                IntToDecimalItemConverter(),
+                ListFieldItemConverter('topics', 'topic', fill=4),
+                SimpleItemConverter(field_converters={'blob_versioned_hashes': array_to_str})
+            ])
     elif item_exporter_type == ItemExporterType.GCS:
         from blockchainetl.jobs.exporters.gcs_item_exporter import GcsItemExporter
         bucket, path = get_bucket_and_path_from_gcs_output(output)

--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -49,6 +49,9 @@ BLOCKS = Table(
     Column('gas_used', BigInteger),
     Column('transaction_count', BigInteger),
     Column('base_fee_per_gas', BigInteger),
+    Column('withdrawals_root', String),
+    Column('blob_gas_used', BigInteger),
+    Column('excess_blob_gas', BigInteger),
 )
 
 TRANSACTIONS = Table(
@@ -78,6 +81,10 @@ TRANSACTIONS = Table(
     Column('receipt_l1_gas_used', BigInteger),
     Column('receipt_l1_gas_price', BigInteger),
     Column('receipt_l1_fee_scalar', Float),
+    Column('max_fee_per_blob_gas', BigInteger),
+    Column('blob_versioned_hashes', String),
+    Column('receipt_blob_gas_price', BigInteger),
+    Column('receipt_blob_gas_used', BigInteger),
 )
 
 LOGS = Table(


### PR DESCRIPTION
This pull request encompasses updates and enhancements to the data conversion logic and schema definitions within the Ethereum ETL project. Key updates include improvements to the `SimpleItemConverter` class for conditional field conversion, expansion of the item exporter creator to include a new converter, and updates to the PostgreSQL schema definitions to accommodate new fields.

**Key Changes:**
- **Data Conversion Logic Updated:** Enhanced the `SimpleItemConverter` to support conditional conversion of fields based on a set of predefined converters.
- **Exporter Updates:** Modified the item exporter creator to include a new `SimpleItemConverter`, improving the handling of specific fields like `blob_versioned_hashes`.
- **Schema Expansion:** Updated PostgreSQL schema definitions for `blocks` and `transactions` to include new fields such as `blob_gas_used`, `excess_blob_gas`, and more.
