### PR TITLE
typos/fix

### DIFF
--- a/blockchainetl/exporters.py
+++ b/blockchainetl/exporters.py
@@ -45,7 +45,7 @@ class BaseItemExporter(object):
         self._configure(kwargs)
 
     def _configure(self, options, dont_fail=False):
-        """Configure the exporter by poping options from the ``options`` dict.
+        """Configure the exporter by popping options from the ``options`` dict.
         If dont_fail is set, it won't raise an exception on unexpected options
         (useful for using with keyword arguments in subclasses constructors)
         """

--- a/ethereumetl/exporters.py
+++ b/ethereumetl/exporters.py
@@ -44,7 +44,7 @@ class BaseItemExporter(object):
         self._configure(kwargs)
 
     def _configure(self, options, dont_fail=False):
-        """Configure the exporter by poping options from the ``options`` dict.
+        """Configure the exporter by popping options from the ``options`` dict.
         If dont_fail is set, it won't raise an exception on unexpected options
         (useful for using with keyword arguments in subclasses constructors)
         """


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
- `ethereumetl/exporters.py:47`: "poping" corrected to "popping".
- `blockchainetl/exporters.py:48`: "poping" corrected to "popping".

## Purpose
- Ensured accuracy and professionalism in code comments and identifiers.
