### PR TITLE
remove broken link to D5.ai

### DIFF
--- a/docs/exporting-the-blockchain.md
+++ b/docs/exporting-the-blockchain.md
@@ -1,6 +1,6 @@
 ## Exporting the Blockchain
 
-If you'd like to have blockchain dataset set up and hosted for you, [get in touch with us at D5](https://d5.ai/?ref=ethereumetl).
+If you'd like to have blockchain dataset set up and hosted for you, [get in touch with us at D5]().
 
 1. Install python 3.5.3+: [https://www.python.org/downloads/](https://www.python.org/downloads/)
 


### PR DESCRIPTION
The link to D5.ai service (https://d5.ai/?ref=ethereumetl) appears to be broken or unreachable.
I've removed the broken link but kept the reference text.
If there's a working or updated link available, feel free to suggest it — I’ll be happy to update the PR accordingly.